### PR TITLE
0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.8.1
+
+- [Bug] Avoid calling `homebridge@1.x.x` new methods if they are not available (#185)
+
 ## 0.8.0
 
 - **[Breaking Change]** The fan speeds are now evenly distributed. So the speeds follow a step-based pattern:

--- a/index.js
+++ b/index.js
@@ -141,7 +141,9 @@ class XiaomiRoborockVacuum {
       .on("get", (cb) => callbackify(() => this.getSerialNumber(), cb));
 
     this.services.fan = new Service.Fan(this.config.name, "Speed");
-    this.services.fan.setPrimaryService(true);
+    if (this.services.fan.setPrimaryService) {
+      this.services.fan.setPrimaryService(true);
+    }
     this.services.fan
       .getCharacteristic(Characteristic.On)
       .on("get", (cb) => callbackify(() => this.getCleaning(), cb))
@@ -1286,7 +1288,9 @@ class XiaomiRoborockVacuum {
     if (this.config.delay) this.sleep(5000);
     this.log.debug(`DEB getServices | ${this.model}`);
     return Object.keys(this.services).map((key) => {
-      if (key !== "fan") this.services.fan.addLinkedService(this.services[key]);
+      if (key !== "fan" && this.services.fan.addLinkedService) {
+        this.services.fan.addLinkedService(this.services[key]);
+      }
       return this.services[key];
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
- [Bug] Avoid calling `homebridge@1.x.x` new methods if they are not available (#185)

Closes #184
Closes #185 