### PR TITLE
Next (0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## next (possibly 0.9.0)
 
-- [Bug] Xiaowa E202-02 fails to go back to the dock (#181) - Thans @bedrin
+- [Bug] Xiaowa E202-02 fails to go back to the dock (#181) - Thanks @bedrin
 
 ## 0.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## next (possibly 0.9.0)
+
+- [Bug] Xiaowa E202-02 fails to go back to the dock (#181) - Thans @bedrin
+
 ## 0.8.2
 
 - [Models] Fix Xiaowa E202-02 modes (#179) - Thank you @bedrin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changes
 
-## next (possibly 0.9.0)
+## 0.9.0
 
 - [Bug] Xiaowa E202-02 fails to go back to the dock (#181) - Thanks @bedrin
+- [Bug] Xiaowa E202-02 successful response is upper-cased "OK" - Thanks @bedrin
+- [Bug] Pause before going to dock (#180) - Thanks @bedrin
+- [Bug] Fixes connection drops and outdated statuses (#146) - Thanks @bedrin
 
 ## 0.8.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ## 0.8.2
 
 - [Models] Fix Xiaowa E202-02 modes (#179) - Thank you @bedrin
+- [Bug] Fix Xiaowa E202-02 fail to go to the dock (#180)
+- [Bug] Fix stalled updates (#146)
 
 ## 0.8.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.9.0-2",
+  "version": "0.9.0-3",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.9.0-4",
+  "version": "0.9.0-5",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.9.0-3",
+  "version": "0.9.0-4",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.9.0-0",
+  "version": "0.9.0-1",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "homebridge": ">=0.4.45"
   },
   "dependencies": {
-    "miio-nicoh88": ">=0.1.0",
+    "miio-nicoh88": "next",
     "semver": "^7.3.2"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.8.2",
+  "version": "0.9.0-0",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.9.0-1",
+  "version": "0.9.0-2",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
To test it, make sure you install `homebridge-xiaomi-roborock-vacuum@next` and restart your homebridge server.

# Changes

- [Bug] Xiaowa E202-02 fails to go back to the dock (#181) - Thanks @bedrin
- [Bug] Xiaowa E202-02 successful response is upper-cased "OK" - Thanks @bedrin
- [Bug] Pause before going to dock (#180) - Thanks @bedrin
- [Bug] Fixes connection drops and outdated statuses (#146) - Thanks @bedrin
