### PR TITLE
Added a few features and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,26 @@
-[![PayPal Donate](https://img.shields.io/badge/PayPal-Donate-blue.svg)](https://www.paypal.me/nh88)
-[![GitHub last commit](https://img.shields.io/github/last-commit/nicoh88/homebridge-xiaomi-roborock-vacuum.svg)](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum)
-[![npm](https://img.shields.io/npm/dt/homebridge-xiaomi-roborock-vacuum.svg)](https://www.npmjs.com/package/homebridge-xiaomi-roborock-vacuum)
-[![npm version](https://badge.fury.io/js/homebridge-xiaomi-roborock-vacuum.svg)](https://badge.fury.io/js/homebridge-xiaomi-roborock-vacuum)
-[![dependencies Status](https://david-dm.org/nicoh88/homebridge-xiaomi-roborock-vacuum/status.svg)](https://david-dm.org/nicoh88/homebridge-xiaomi-roborock-vacuum)
-
-# homebridge-xiaomi-roborock-vacuum
-
-## Homebridge plugin for Xiaomi / Roborock Vacuum Cleaner's
-
-With this [homebridge](https://github.com/nfarina/homebridge) plugin can you control the xiaomi vacuum robots as fan in your Apple Home App (HomeKit).
-
-This plugin use the new [miio](https://github.com/aholstenson/miio) version 0.15.6 or newer, not like the old ones 0.14.1. Timeouts and API errors are a thing of the past!
-
-<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/rockrobo.vacuum.v1.jpg" style="border:1px solid lightgray" alt="Xiaomi Mi Robot 1st Generation (Roborock Vacuum V1)" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.s5.jpg" style="border:1px solid lightgray" alt="Roborock S50 2nd Generation" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.s55.jpg" style="border:1px solid lightgray" alt="Roborock S55 2nd Generation Black" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.s6.jpg" style="border:1px solid lightgray" alt="Roborock S6/T6 3nd Generation" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.c10.jpg" style="border:1px solid lightgray" alt="Roborock Xiaowa Lite C10" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.s5.max.jpg" style="border:1px solid lightgray" alt="Roborock S5 Max" width="300">
+# homebridge-roborock
+This plugin is a fork of homebridge-xiaomi-roborock-vacuum (thanks to Nico Hartung) with the following changes:
+1) Changed the logic to periodically pull status from the device, make the accessories more responsive 
+2) Added support for go to target function 
+3) The room switches can be used to select multiple rooms before start cleaning. When cleaning fan is powered on, it automatically detects if the device should do a full house clean or room clean based on if any room is enabled for cleaning
+4) Fixed the resume function so now it's possible to resume from room cleaning mode
+5) More validation logic added together with some other small improvements
+6) Fixed no gentle mode for Roborock S5
+7) Auto configure the minimal step for fan service so for models with 4 speeds it will be 25% each level and for models with 5 speeds it will be 20% each level. It is no longer possible to choose other percentages. 
 
 ## Features
-
-- **Fan** as On-/Off-Switch. When switching off, directly back to the charging station.
-  - [Fanspeed levels](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/blob/master/models/speedmodes.js) adjustable via 3D Touch / Force Touch.
-- Battery status and condition in the device details. Low battery alert.
-- Pause switch (optional).
-- Room cleaning (optional): Read [Autoroom generation](#autoroom-generation) to understand how it works
-- Occupancy sensor (similar to motion sensor) for dock status (optional).
-- Seconds Fan for water box modes (optional).
+* **Fan** as On-/Off-Switch. When switching off, directly back to the charging station.
+   * [Fanspeed levels](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/blob/master/models/speedmodes.js) adjustable via 3D Touch / Force Touch.
+* Battery status and condition in the device details. Low battery alert.
+* Pause switch (optional).
+* Occupancy sensor (similar to motion sensor) for dock status (optional).
+* Seconds Fan for water box modes (optional).
 
 <img src="https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/blob/master/screenshot1.jpg?raw=true" alt="Screenshot Apple HomeKit with homebridge-xiaomi-roborock-vacuum" width="350">
 <img src="https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/blob/master/screenshot2.jpg?raw=true" alt="Screenshot Elgato Eve App with homebridge-xiaomi-roborock-vacuum" width="350">
 
-## Instructions
 
+## Instructions
 1. Install git packages first with `sudo apt install git`.
 2. Install the plugin as `root` (`sudo su -`) with `npm install -g homebridge-xiaomi-roborock-vacuum@latest --unsafe-perm`.
 3. Customize you homebridge configuration `config.json`.
@@ -39,11 +31,11 @@ This plugin use the new [miio](https://github.com/aholstenson/miio) version 0.15
 ```
 "accessories": [
  {
-  "accessory": "XiaomiRoborockVacuum",
-  "name": "Xiaomi Mi Robot Vaccum 1st Generation",
+  "accessory": "RoborockVacuum",
+  "name": "My Roborock Cleaner",
   "ip": "192.168.1.150",
   "token": "abcdef1234567890abcdef1234567890",
-  "pause": false,
+  "pause": true,
   "dock": true,
   "waterBox": false,
   "cleanword": "cleaning",
@@ -56,85 +48,39 @@ This plugin use the new [miio](https://github.com/aholstenson/miio) version 0.15
       "id": 17,
       "name": "Kitchen"
     }
-  ],
-  "zones": [
- {
-      "name":"Family Room (x2)",
-      "zone":[[25000,25000,32000,32000,2]]
-    },
-    {
-      "name":"Bedroom",
-      "zone":[[21000,32000,24000,37000,1]]
-    },
-    {
-      "name":"Bedroom & Family Room",
-      "zone":[ [21000,32000,24000,37000,1],  [25000,25000,32000,32000,1]]
-    }
   ]
- }
-],
-```
-
-- Example `config.json` with two vacuums:
-
-```
-"accessories": [
- {
-  "accessory": "XiaomiRoborockVacuum",
-  "name": "Xiaomi Mi Robot Vaccum 1st Generation",
-  "ip": "192.168.1.150",
-  "token": "abcdef1234567890abcdef1234567890",
-  "pause": false,
-  "dock": true,
-  "waterBox": false
  },
- {
-  "accessory": "XiaomiRoborockVacuum",
-  "name": "Xiaomi Roborock S50 Vaccum 2nd Generation",
-  "ip": "192.168.1.151",
-  "token": "1234567890abcdef1234567890abcdef",
-  "pause": false,
-  "dock": true,
-  "waterBox": false
- }
+ "gotoTarget": {
+    "name": "Go to Bin",
+    "target": [
+          21659,
+          33063
+    ]
+  }
 ],
 ```
 
 ## Optional parameters
-
-| Name of parameter | Default value | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| ----------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pause`           | false         | when set to true, HomeKit shows an additional switch for "pause" - switch is on, when pause is possible                                                                                                                                                                                                                                                                                                                                                                                      |
-| `dock`            | false         | when set to true, HomeKit shows an occupancy sensor, if robot is in the charging dock                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `waterBox`        | false         | when set to true, HomeKit shows an additional slider to control the amount of water released by the robot (only selected models like S5-Max). Currently in a beta state.                                                                                                                                                                                                                                                                                                                     |
-| `cleanword`       | cleaning      | used for autonaming the Roomselectors                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `rooms`           | false         | Array of ID / Name for a single Room. If set you have another switch for cleaning only this room                                                                                                                                                                                                                                                                                                                                                                                             |
-| `zones`           | false         | Array of name / zone coordinates for a single zone group. A zone group may contain multiple zone squares, each with its own value for number of cleanings. Coordinates are laid out as bottom-left-x, bottom-left-y, top-right-x, top-right-y, number-of-cleanings. A separate tile in Home will be created for each zone group. Figuring out coordinates will take some trial and error. Each zone should be surrounded by brackets: [], with the entire value also surrounded by brackets. |
-| `autoroom`        | false         | set to true to generate rooms from robot (only S6) or set to array of room name strings (see semi automatic below)                                                                                                                                                                                                                                                                                                                                                                           |
+| Name of parameter | Default value | Notes |
+|---|---|---|
+| `pause` | false | when set to true, HomeKit shows an additional switch for "pause" - switch is on, when pause is possible |
+| `dock` | false |  when set to true, HomeKit shows an occupancy sensor, if robot is in the charging dock |
+| `waterBox` | false | when set to true, HomeKit shows an additional slider to control the amount of water released by the robot (only selected models like S5-Max). Currently in a beta state. |
+| `cleanword` | cleaning | used for autonaming the Roomselectors |
+| `rooms` | null | Array of ID / Name for a single Room. If set you have another switch for cleaning only this room |
+| `autoroom` | false | when set to true, Rooms will be generated from Robot. (only S6) |
+| `gotoTarget` | null | Configure a switch to allow the device to go to target specified by the coordinates |
 
 ## AutoRoom Generation
+This feature seems to be working only on the S6 Model.
+We figured out this is why the Api call only delivers the mapping when the Rooms are named in the Xioami / Roborock App.
 
-### Semi automatic
-
-This feature seems to work with all models which offer room cleaning. To use it:
-
-1. Set the `autoroom` property in the config to an array of room names (`["my room 1", "my room 2", "my room 3"]`. 
-2. In the Xiaomi Mi app, setup a timer at midnight (00:00 or 12:00am).
-3. Enable `Select a room to divide`. 
-4. On the map select the rooms in the order as they appear in the config set in step 1. The order is important as this is how the plugin maps the room names to IDs.
-5. Submit the timer and make sure it's deactivated. 
-6. Restart `homebridge`.
-
-### Fully automatic
-
-This feature seems to be working **only on the S6 Model** because it's the only that supports naming the rooms in the Xiaomi / Roborock App.
-
-Even if you have an S6 but you haven't named the Rooms in your App yet, this function will not work! Thanks @domeOo
+So when you have an S6 but not named the Rooms in your App this function will not work! Thanks @domeOo
 
 ## Xiaomi Token
-
 To use this plugin, you have to read the "token" of the xiaomi vacuum robots. Here are some detailed instructions:
-
 - :us::gb: - [python-miio - Getting started](https://python-miio.readthedocs.io/en/latest/discovery.html)
 - :de: - [Apple HomeKit Forum - HomeKit.Community](https://forum.smartapfel.de/forum/thread/370-xiaomi-token-auslesen/)
 - :de: - [Homematic-Guru.de](https://homematic-guru.de/xiaomi-vacuum-staubsauger-roboter-mit-homematic-steuern)
+
+

--- a/config.schema.json
+++ b/config.schema.json
@@ -102,7 +102,10 @@
     {
       "type": "flex",
       "flex-flow": "row wrap",
-      "items": ["ip", "token"]
+      "items": [
+        "ip",
+        "token"
+      ]
     },
     "waterBox",
     "pause",
@@ -113,7 +116,7 @@
     {
       "type": "fieldset",
       "title": "Rooms",
-      "description": "Room Mapping",
+      "description": "Room Mapping", 
       "expandable": true,
       "expanded": false,
       "items": [
@@ -148,7 +151,7 @@
     {
       "type": "fieldset",
       "title": "Zones",
-      "description": "Zone cleaning",
+      "description": "Zone cleaning", 
       "expandable": true,
       "expanded": false,
       "items": [

--- a/index.js
+++ b/index.js
@@ -1,23 +1,19 @@
-"use strict";
+'use strict';
 
-const semver = require("semver");
-const miio = require("miio-nicoh88");
-const util = require("util");
-const callbackify = require("./lib/callbackify");
-const safeCall = require("./lib/safeCall");
-let sleep;
-try {
-  sleep = require("system-sleep");
-} catch (e) {
-  // noop
-}
+const semver = require('semver');
+const miio = require('miio');
+const util = require('util');
+const callbackify = require('./lib/callbackify');
+const safeCall = require('./lib/safeCall');
+const sleep = require('system-sleep');
 
 let homebrideAPI, Service, Characteristic;
 
-const PLUGIN_NAME = "homebridge-xiaomi-roborock-vacuum";
-const ACCESSORY_NAME = "XiaomiRoborockVacuum";
+//Changed by Mai
+const PLUGIN_NAME = 'homebridge-roborock';
+const ACCESSORY_NAME = 'RoborockVacuum';
 
-const MODELS = require("./models");
+const MODELS = require('./models');
 const GET_STATE_INTERVAL_MS = 30000; // 30s
 
 module.exports = function (homebridge) {
@@ -27,81 +23,61 @@ module.exports = function (homebridge) {
   homebrideAPI = homebridge;
   // UUIDGen = homebridge.hap.uuid;
 
-  homebridge.registerAccessory(
-    PLUGIN_NAME,
-    ACCESSORY_NAME,
-    XiaomiRoborockVacuum
-  );
-};
+  homebridge.registerAccessory(PLUGIN_NAME, ACCESSORY_NAME, XiaomiRoborockVacuum);
+}
 
 class XiaomiRoborockVacuum {
   // From https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L128
   static get cleaningStatuses() {
-    return ["cleaning", "spot-cleaning", "zone-cleaning", "room-cleaning"];
+    return [
+      'cleaning',
+      'spot-cleaning',
+      'zone-cleaning',
+      'room-cleaning'
+    ];
   }
 
   static get errors() {
     return {
-      id1: {
-        description:
-          "Try turning the orange laserhead to make sure it isnt blocked.",
-      },
-      id2: { description: "Clean and tap the bumpers lightly." },
-      id3: { description: "Try moving the vacuum to a different place." },
-      id4: {
-        description:
-          "Wipe the cliff sensor clean and move the vacuum to a different place.",
-      },
-      id5: { description: "Remove and clean the main brush." },
-      id6: { description: "Remove and clean the sidebrushes." },
-      id7: {
-        description:
-          "Make sure the wheels arent blocked. Move the vacuum to a different place and try again.",
-      },
-      id8: {
-        description: "Make sure there are no obstacles around the vacuum.",
-      },
-      id9: { description: "Install the dustbin and the filter." },
-      id10: {
-        description: "Make sure the filter has been tried or clean the filter.",
-      },
-      id11: {
-        description:
-          "Strong magnetic field detected. Move the device away from the virtual wall and try again",
-      },
-      id12: { description: "Battery is low, charge your vacuum." },
-      id13: {
-        description:
-          "Couldnt charge properly. Make sure the charging surfaces are clean.",
-      },
-      id14: { description: "Battery malfunctioned." },
-      id15: { description: "Wipe the wall sensor clean." },
-      id16: { description: "Use the vacuum on a flat horizontal surface." },
-      id17: { description: "Sidebrushes malfunctioned. Reboot the system." },
-      id18: { description: "Fan malfunctioned. Reboot the system." },
-      id19: { description: "The docking station is not connected to power." },
-      id20: { description: "unkown" },
-      id21: {
-        description:
-          "Please make sure that the top cover of the laser distance sensor is not pinned.",
-      },
-      id22: { description: "Please wipe the dock sensor." },
-      id23: {
-        description: "Make sure the signal emission area of dock is clean.",
-      },
+      id1: { description: 'Try turning the orange laserhead to make sure it isnt blocked.' },
+      id2: { description: 'Clean and tap the bumpers lightly.' },
+      id3: { description: 'Try moving the vacuum to a different place.' },
+      id4: { description: 'Wipe the cliff sensor clean and move the vacuum to a different place.' },
+      id5: { description: 'Remove and clean the main brush.' },
+      id6: { description: 'Remove and clean the sidebrushes.' },
+      id7: { description: 'Make sure the wheels arent blocked. Move the vacuum to a different place and try again.' },
+      id8: { description: 'Make sure there are no obstacles around the vacuum.' },
+      id9: { description: 'Install the dustbin and the filter.' },
+      id10: { description: 'Make sure the filter has been tried or clean the filter.' },
+      id11: { description: 'Strong magnetic field detected. Move the device away from the virtual wall and try again' },
+      id12: { description: 'Battery is low, charge your vacuum.' },
+      id13: { description: 'Couldnt charge properly. Make sure the charging surfaces are clean.' },
+      id14: { description: 'Battery malfunctioned.' },
+      id15: { description: 'Wipe the wall sensor clean.' },
+      id16: { description: 'Use the vacuum on a flat horizontal surface.' },
+      id17: { description: 'Sidebrushes malfunctioned. Reboot the system.' },
+      id18: { description: 'Fan malfunctioned. Reboot the system.' },
+      id19: { description: 'The docking station is not connected to power.' },
+      id20: { description: 'unkown' },
+      id21: { description: 'Please make sure that the top cover of the laser distance sensor is not pinned.' },
+      id22: { description: 'Please wipe the dock sensor.' },
+      id23: { description: 'Make sure the signal emission area of dock is clean.' }
     };
   }
 
   constructor(log, config) {
     this.log = log;
     this.config = config;
-    this.config.name = config.name || "Roborock vacuum cleaner";
-    this.config.cleanword = config.cleanword || "cleaning";
+    this.config.name = config.name || 'Roborock vacuum cleaner';
+    this.config.cleanword = config.cleanword || 'cleaning';
     this.config.delay = config.delay || false;
     this.services = {};
 
     // Used to store the latest state to reduce logging
     this.cachedState = new Map();
+
+    //Changed by Mai
+    this.roomsToClean = [];
 
     this.device = null;
     this.connectingPromise = null;
@@ -109,11 +85,11 @@ class XiaomiRoborockVacuum {
     this.getStateInterval = setInterval(() => void 0, GET_STATE_INTERVAL_MS); // Noop timeout only to initialise the property
 
     if (!this.config.ip) {
-      throw new Error("You must provide an ip address of the vacuum cleaner.");
+      throw new Error('You must provide an ip address of the vacuum cleaner.');
     }
 
     if (!this.config.token) {
-      throw new Error("You must provide a token of the vacuum cleaner.");
+      throw new Error('You must provide a token of the vacuum cleaner.');
     }
 
     // HOMEKIT SERVICES
@@ -128,86 +104,64 @@ class XiaomiRoborockVacuum {
   initialiseServices() {
     this.services.info = new Service.AccessoryInformation();
     this.services.info
-      .setCharacteristic(Characteristic.Manufacturer, "Xiaomi")
-      .setCharacteristic(Characteristic.Model, "Roborock");
+      .setCharacteristic(Characteristic.Manufacturer, 'Xiaomi')
+      .setCharacteristic(Characteristic.Model, 'Roborock');
     this.services.info
       .getCharacteristic(Characteristic.FirmwareRevision)
-      .on("get", (cb) => callbackify(() => this.getFirmware(), cb));
+      .on('get', (cb) => callbackify(() => this.getFirmware(), cb));
     this.services.info
       .getCharacteristic(Characteristic.Model)
-      .on("get", (cb) => callbackify(() => this.device.miioModel, cb));
+      .on('get', (cb) => callbackify(() => this.device.miioModel, cb));
     this.services.info
       .getCharacteristic(Characteristic.SerialNumber)
-      .on("get", (cb) => callbackify(() => this.getSerialNumber(), cb));
+      .on('get', (cb) => callbackify(() => this.getSerialNumber(), cb));
 
-    this.services.fan = new Service.Fan(this.config.name, "Speed");
-    if (this.services.fan.setPrimaryService) {
-      this.services.fan.setPrimaryService(true);
-    }
+    this.services.fan = new Service.Fan(this.config.name, 'Speed');
     this.services.fan
       .getCharacteristic(Characteristic.On)
-      .on("get", (cb) => callbackify(() => this.getCleaning(), cb))
-      .on("set", (newState, cb) =>
-        callbackify(() => this.setCleaning(newState), cb)
-      )
-      .on("change", (oldState, newState) => {
+      .on('get', (cb) => callbackify(() => this.getCleaning(), cb))
+      .on('set', (newState, cb) => callbackify(() => this.setCleaning(newState), cb))
+      .on('change', (oldState, newState) => {
         this.changedPause(newState);
       });
-    this.services.fan
-      .getCharacteristic(Characteristic.RotationSpeed)
-      .on("get", (cb) => callbackify(() => this.getSpeed(), cb))
-      .on("set", (newState, cb) =>
-        callbackify(() => this.setSpeed(newState), cb)
-      );
+    //this.services.fan
+      //.getCharacteristic(Characteristic.RotationSpeed).on('get', (cb) => callbackify(() => this.getSpeed(), cb))
+      //.on('set', (newState, cb) => callbackify(() => this.setSpeed(newState), cb));
 
     if (this.config.waterBox) {
-      this.services.waterBox = new Service.Fan(
-        `${this.config.name} Water Box`,
-        "Water Box"
-      );
+      this.services.waterBox = new Service.Fan(`${this.config.name} Water Box`, 'Water Box');
       // TODO: Do we need to manage the Characteristic.On?
       this.services.waterBox
         .getCharacteristic(Characteristic.RotationSpeed)
-        .on("get", (cb) => callbackify(() => this.getWaterSpeed(), cb))
-        .on("set", (newState, cb) =>
-          callbackify(() => this.setWaterSpeed(newState), cb)
-        );
+        .on('get', (cb) => callbackify(() => this.getWaterSpeed(), cb))
+        .on('set', (newState, cb) => callbackify(() => this.setWaterSpeed(newState), cb));
     }
 
-    this.services.battery = new Service.BatteryService(
-      `${this.config.name} Battery`
-    );
+    this.services.battery = new Service.BatteryService(`${this.config.name} Battery`);
     this.services.battery
       .getCharacteristic(Characteristic.BatteryLevel)
-      .on("get", (cb) => callbackify(() => this.getBattery(), cb));
+      .on('get', (cb) => callbackify(() => this.getBattery(), cb));
     this.services.battery
       .getCharacteristic(Characteristic.ChargingState)
-      .on("get", (cb) => callbackify(() => this.getCharging(), cb));
+      .on('get', (cb) => callbackify(() => this.getCharging(), cb));
     this.services.battery
       .getCharacteristic(Characteristic.StatusLowBattery)
-      .on("get", (cb) => callbackify(() => this.getBatteryLow(), cb));
+      .on('get', (cb) => callbackify(() => this.getBatteryLow(), cb));
 
     if (this.config.pause) {
-      this.services.pause = new Service.Switch(
-        `${this.config.name} Pause`,
-        "Pause Switch"
-      );
+      this.services.pause = new Service.Switch(`${this.config.name} Pause`, 'Pause Switch');
       this.services.pause
         .getCharacteristic(Characteristic.On)
-        .on("get", (cb) => callbackify(() => this.getPauseState(), cb))
-        .on("set", (newState, cb) =>
-          callbackify(() => this.setPauseState(newState), cb)
-        );
+        .on('get', (cb) => callbackify(() => this.getPauseState(), cb))
+        .on('set', (newState, cb) => callbackify(() => this.setPauseState(newState), cb));
       // TODO: Add 'change' status?
     }
 
     if (this.config.dock) {
-      this.services.dock = new Service.OccupancySensor(
-        `${this.config.name} Dock`
-      );
+      this.services.dock = new Service.OccupancySensor(`${this.config.name} Dock`);
       this.services.dock
         .getCharacteristic(Characteristic.OccupancyDetected)
-        .on("get", (cb) => callbackify(() => this.getDocked(), cb));
+        .on('get', (cb) => callbackify(() => this.getDocked(), cb));
     }
 
     if (this.config.rooms && !this.config.autoroom) {
@@ -216,17 +170,18 @@ class XiaomiRoborockVacuum {
       }
     }
 
-    // Declare services for rooms in advance, so HomeKit can create the switches
-    if (this.config.autoroom && Array.isArray(this.config.autoroom)) {
-      for (const i in this.config.autoroom) {
-        // Index will be overwritten, when robot is available
-        this.createRoom(i, this.config.autoroom[i]);
-      }
-    }
-
     if (this.config.zones) {
       for (var i in this.config.zones) {
         this.createZone(this.config.zones[i].name, this.config.zones[i].zone);
+      }
+    }
+    //Changed by Mai
+    if (this.config.gotoTarget) {
+      if (this.config.gotoTarget.target && this.config.gotoTarget.target.length == 2) {
+        var name = this.config.gotoTarget.name || 'Go to';
+        this.services.gotoTarget = new Service.Switch(name, 'GotoTargetSwitch');
+        this.services.gotoTarget.getCharacteristic(Characteristic.On).on('get', (cb) => callbackify(() => this.getGotoTarget(), cb)).
+          on('set', (newState, cb) => callbackify(() => this.setGotoTarget(newState, this.config.gotoTarget.target), cb));
       }
     }
 
@@ -235,178 +190,82 @@ class XiaomiRoborockVacuum {
   }
 
   initialiseCareServices() {
-    if (this.config.legacyCareSensors) {
-      Characteristic.CareSensors = function () {
-        Characteristic.call(
-          this,
-          "Care indicator sensors",
-          "00000101-0000-0000-0000-000000000000"
-        );
-        this.setProps({
-          format: Characteristic.Formats.FLOAT,
-          unit: "%",
-          perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        });
-        this.value = this.getDefaultValue();
-      };
-      util.inherits(Characteristic.CareSensors, Characteristic);
-      Characteristic.CareSensors.UUID = "00000101-0000-0000-0000-000000000000";
+    Characteristic.CareSensors = function () {
+      Characteristic.call(this, 'Care indicator sensors', '00000101-0000-0000-0000-000000000000');
+      this.setProps({
+        format: Characteristic.Formats.FLOAT,
+        unit: '%',
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    util.inherits(Characteristic.CareSensors, Characteristic);
+    Characteristic.CareSensors.UUID = '00000101-0000-0000-0000-000000000000';
 
-      Characteristic.CareFilter = function () {
-        Characteristic.call(
-          this,
-          "Care indicator filter",
-          "00000102-0000-0000-0000-000000000000"
-        );
-        this.setProps({
-          format: Characteristic.Formats.FLOAT,
-          unit: "%",
-          perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        });
-        this.value = this.getDefaultValue();
-      };
-      util.inherits(Characteristic.CareFilter, Characteristic);
-      Characteristic.CareFilter.UUID = "00000102-0000-0000-0000-000000000000";
+    Characteristic.CareFilter = function () {
+      Characteristic.call(this, 'Care indicator filter', '00000102-0000-0000-0000-000000000000');
+      this.setProps({
+        format: Characteristic.Formats.FLOAT,
+        unit: '%',
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    util.inherits(Characteristic.CareFilter, Characteristic);
+    Characteristic.CareFilter.UUID = '00000102-0000-0000-0000-000000000000';
 
-      Characteristic.CareSideBrush = function () {
-        Characteristic.call(
-          this,
-          "Care indicator side brush",
-          "00000103-0000-0000-0000-000000000000"
-        );
-        this.setProps({
-          format: Characteristic.Formats.FLOAT,
-          unit: "%",
-          perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        });
-        this.value = this.getDefaultValue();
-      };
-      util.inherits(Characteristic.CareSideBrush, Characteristic);
-      Characteristic.CareSideBrush.UUID =
-        "00000103-0000-0000-0000-000000000000";
+    Characteristic.CareSideBrush = function () {
+      Characteristic.call(this, 'Care indicator side brush', '00000103-0000-0000-0000-000000000000');
+      this.setProps({
+        format: Characteristic.Formats.FLOAT,
+        unit: '%',
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    util.inherits(Characteristic.CareSideBrush, Characteristic);
+    Characteristic.CareSideBrush.UUID = '00000103-0000-0000-0000-000000000000';
 
-      Characteristic.CareMainBrush = function () {
-        Characteristic.call(
-          this,
-          "Care indicator main brush",
-          "00000104-0000-0000-0000-000000000000"
-        );
-        this.setProps({
-          format: Characteristic.Formats.FLOAT,
-          unit: "%",
-          perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        });
-        this.value = this.getDefaultValue();
-      };
-      util.inherits(Characteristic.CareMainBrush, Characteristic);
-      Characteristic.CareMainBrush.UUID =
-        "00000104-0000-0000-0000-000000000000";
+    Characteristic.CareMainBrush = function () {
+      Characteristic.call(this, 'Care indicator main brush', '00000104-0000-0000-0000-000000000000');
+      this.setProps({
+        format: Characteristic.Formats.FLOAT,
+        unit: '%',
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+      });
+      this.value = this.getDefaultValue();
+    };
+    util.inherits(Characteristic.CareMainBrush, Characteristic);
+    Characteristic.CareMainBrush.UUID = '00000104-0000-0000-0000-000000000000';
 
-      Service.Care = function (displayName, subtype) {
-        Service.call(
-          this,
-          displayName,
-          "00000111-0000-0000-0000-000000000000",
-          subtype
-        );
-        this.addCharacteristic(Characteristic.CareSensors);
-        this.addCharacteristic(Characteristic.CareFilter);
-        this.addCharacteristic(Characteristic.CareSideBrush);
-        this.addCharacteristic(Characteristic.CareMainBrush);
-      };
-      util.inherits(Service.Care, Service);
-      Service.Care.UUID = "00000111-0000-0000-0000-000000000000";
+    Service.Care = function (displayName, subtype) {
+      Service.call(this, displayName, '00000111-0000-0000-0000-000000000000', subtype);
+      this.addCharacteristic(Characteristic.CareSensors);
+      this.addCharacteristic(Characteristic.CareFilter);
+      this.addCharacteristic(Characteristic.CareSideBrush);
+      this.addCharacteristic(Characteristic.CareMainBrush);
+    };
+    util.inherits(Service.Care, Service);
+    Service.Care.UUID = '00000111-0000-0000-0000-000000000000';
 
-      this.services.Care = new Service.Care(`${this.config.name} Care`);
-      this.services.Care.getCharacteristic(Characteristic.CareSensors).on(
-        "get",
-        (cb) => callbackify(() => this.getCareSensors(), cb)
-      );
-      this.services.Care.getCharacteristic(Characteristic.CareFilter).on(
-        "get",
-        (cb) => callbackify(() => this.getCareFilter(), cb)
-      );
-      this.services.Care.getCharacteristic(
-        Characteristic.CareSideBrush
-      ).on("get", (cb) => callbackify(() => this.getCareSideBrush(), cb));
-      this.services.Care.getCharacteristic(
-        Characteristic.CareMainBrush
-      ).on("get", (cb) => callbackify(() => this.getCareMainBrush(), cb));
-    } else {
-      // Use Homekit's native FilterMaintenance Service
-      this.services.CareSensors = new Service.FilterMaintenance(
-        "Care indicator sensors",
-        "sensors"
-      );
-      this.services.CareSensors.getCharacteristic(
-        Characteristic.FilterChangeIndication
-      ).on("get", (cb) =>
-        callbackify(async () => {
-          return (await this.getCareSensors()) >= 100;
-        }, cb)
-      );
-      this.services.CareSensors.getCharacteristic(
-        Characteristic.FilterLifeLevel
-      ).on("get", (cb) =>
-        callbackify(async () => 100 - (await this.getCareSensors()), cb)
-      );
-
-      this.services.CareFilter = new Service.FilterMaintenance(
-        "Care indicator filter",
-        "filter"
-      );
-      this.services.CareFilter.getCharacteristic(
-        Characteristic.FilterChangeIndication
-      ).on("get", (cb) =>
-        callbackify(async () => {
-          return (await this.getCareFilter()) >= 100;
-        }, cb)
-      );
-      this.services.CareFilter.getCharacteristic(
-        Characteristic.FilterLifeLevel
-      ).on("get", (cb) =>
-        callbackify(async () => 100 - (await this.getCareFilter()), cb)
-      );
-
-      this.services.CareSideBrush = new Service.FilterMaintenance(
-        "Care indicator side brush",
-        "side brush"
-      );
-      this.services.CareSideBrush.getCharacteristic(
-        Characteristic.FilterChangeIndication
-      ).on("get", (cb) =>
-        callbackify(async () => {
-          return (await this.getCareSideBrush()) >= 100;
-        }, cb)
-      );
-      this.services.CareSideBrush.getCharacteristic(
-        Characteristic.FilterLifeLevel
-      ).on("get", (cb) =>
-        callbackify(async () => 100 - (await this.getCareSideBrush()), cb)
-      );
-
-      this.services.CareMainBrush = new Service.FilterMaintenance(
-        "Care indicator main brush",
-        "main brush"
-      );
-      this.services.CareMainBrush.getCharacteristic(
-        Characteristic.FilterChangeIndication
-      ).on("get", (cb) =>
-        callbackify(async () => {
-          return (await this.getCareMainBrush()) >= 100;
-        }, cb)
-      );
-      this.services.CareMainBrush.getCharacteristic(
-        Characteristic.FilterLifeLevel
-      ).on("get", (cb) =>
-        callbackify(async () => 100 - (await this.getCareMainBrush()), cb)
-      );
-    }
+    this.services.Care = new Service.Care(`${this.config.name} Care`)
+    this.services.Care
+      .getCharacteristic(Characteristic.CareSensors)
+      .on('get', (cb) => callbackify(() => this.getCareSensors(), cb));
+    this.services.Care
+      .getCharacteristic(Characteristic.CareFilter)
+      .on('get', (cb) => callbackify(() => this.getCareFilter(), cb));
+    this.services.Care
+      .getCharacteristic(Characteristic.CareSideBrush)
+      .on('get', (cb) => callbackify(() => this.getCareSideBrush(), cb));
+    this.services.Care
+      .getCharacteristic(Characteristic.CareMainBrush)
+      .on('get', (cb) => callbackify(() => this.getCareMainBrush(), cb));
   }
 
   /**
    * Returns if the newValue is different to the previously cached one
-   *
+   * 
    * @param {string} property
    * @param {any} newValue
    * @returns {boolean} Whether the newValue is not the same as the previously cached one.
@@ -418,173 +277,108 @@ class XiaomiRoborockVacuum {
   }
 
   changedError(robotError) {
-    if (!robotError) return;
-    this.log.debug(
-      `DEB changedError | ${this.model} | ErrorID: ${robotError.id}, ErrorDescription: ${robotError.description}`
-    );
-    let robotErrorTxt = XiaomiRoborockVacuum.errors[`id${robotError.id}`]
-      ? XiaomiRoborockVacuum.errors[`id${robotError.id}`].description
-      : `Unknown ERR | errorid can't be mapped. (${robotError.id})`;
-    if (!`${robotError.description}`.toLowerCase().startsWith("unknown")) {
+    this.log.debug(`DEB changedError | ${this.model} | ErrorID: ${robotError.id}, ErrorDescription: ${robotError.description}`);
+    let robotErrorTxt = XiaomiRoborockVacuum.errors[`id${robotError.id}`] ?
+      XiaomiRoborockVacuum.errors[`id${robotError.id}`].description :
+      `Unknown ERR | errorid can't be mapped. (${robotError.id})`;
+    if (!`${robotError.description}`.toLowerCase().startsWith('unknown')) {
       robotErrorTxt = robotError.description;
     }
-    this.log.warn(
-      `WAR changedError | ${this.model} | Robot has an ERROR - ${robotError.id}, ${robotErrorTxt}`
-    );
-    // Clear the error_code property
-    this.device.setProperty("error_code", null);
+    this.log.warn(`WAR changedError | ${this.model} | Robot has an ERROR - ${robotError.id}, ${robotErrorTxt}`);
   }
 
   changedCleaning(isCleaning) {
-    if (this.isNewValue("cleaning", isCleaning)) {
-      this.log.debug(
-        `MON changedCleaning | ${this.model} | CleaningState is now ${isCleaning}`
-      );
-      this.log.info(
-        `INF changedCleaning | ${this.model} | Cleaning is ${
-          isCleaning ? "ON" : "OFF"
-        }.`
-      );
+    if (this.isNewValue('cleaning', isCleaning)) {
+      this.log.debug(`MON changedCleaning | ${this.model} | CleaningState is now ${isCleaning}`);
+      this.log.info(`INF changedCleaning | ${this.model} | Cleaning is ${isCleaning ? 'ON' : 'OFF'}.`);
+      //Changed by Mai
+      if (!isCleaning) {
+        this.roomsToClean.length = 0;
+      }
     }
     // We still update the value in Homebridge. If we are calling the changed method is because we want to change it.
-    this.services.fan
-      .getCharacteristic(Characteristic.On)
-      .updateValue(isCleaning);
+    this.services.fan.getCharacteristic(Characteristic.On).updateValue(isCleaning);
   }
 
   changedPause(isCleaning) {
     if (this.config.pause) {
-      if (this.isNewValue("pause", isCleaning)) {
-        this.log.debug(
-          `MON changedPause | ${this.model} | CleaningState is now ${isCleaning}`
-        );
-        this.log.info(
-          `INF changedPause | ${this.model} | ${
-            isCleaning ? "Paused possible" : "Paused not possible, no cleaning"
-          }`
-        );
+      if (this.isNewValue('pause', isCleaning)) {
+        this.log.debug(`MON changedPause | ${this.model} | CleaningState is now ${isCleaning}`);
+        this.log.info(`INF changedPause | ${this.model} | ${isCleaning ? 'Paused possible' : 'Paused not possible, no cleaning'}`);
       }
       // We still update the value in Homebridge. If we are calling the changed method is because we want to change it.
-      this.services.pause
-        .getCharacteristic(Characteristic.On)
-        .updateValue(isCleaning);
+      this.services.pause.getCharacteristic(Characteristic.On).updateValue(isCleaning);
     }
   }
 
   changedCharging(isCharging) {
-    const isNewValue = this.isNewValue("charging", isCharging);
+    const isNewValue = this.isNewValue('charging', isCharging);
     if (isNewValue) {
-      this.log.info(
-        `MON changedCharging | ${this.model} | ChargingState is now ${isCharging}`
-      );
-      this.log.info(
-        `INF changedCharging | ${this.model} | Charging is ${
-          isCharging ? "active" : "cancelled"
-        }`
-      );
+      this.log.info(`INF changedCharging | ${this.model} | Charging is ${isCharging ? 'active' : 'cancelled'}`);
     }
     // We still update the value in Homebridge. If we are calling the changed method is because we want to change it.
-    this.services.battery
-      .getCharacteristic(Characteristic.ChargingState)
-      .updateValue(
-        isCharging
-          ? Characteristic.ChargingState.CHARGING
-          : Characteristic.ChargingState.NOT_CHARGING
-      );
+    this.services.battery.getCharacteristic(Characteristic.ChargingState).updateValue(isCharging ? Characteristic.ChargingState.CHARGING : Characteristic.ChargingState.NOT_CHARGING);
     if (this.config.dock) {
       if (isNewValue) {
-        const msg = isCharging
-          ? "Robot was docked"
-          : "Robot not anymore in dock";
+        const msg = isCharging ? 'Robot was docked' : 'Robot not anymore in dock';
         this.log.info(`INF changedCharging | ${this.model} | ${msg}.`);
       }
-      this.services.dock
-        .getCharacteristic(Characteristic.OccupancyDetected)
-        .updateValue(isCharging);
+      this.services.dock.getCharacteristic(Characteristic.OccupancyDetected).updateValue(isCharging);
     }
   }
 
   changedSpeed(speed) {
-    const isNewValue = this.isNewValue("speed", speed);
+    const isNewValue = this.isNewValue('speed', speed);
     if (isNewValue) {
-      this.log.info(
-        `MON changedSpeed | ${this.model} | FanSpeed is now ${speed}%`
-      );
+      this.log.info(`MON changedSpeed | ${this.model} | FanSpeed is now ${speed}%`);
     }
 
     const speedMode = this.findSpeedModeFromMiio(speed);
 
     if (typeof speedMode === "undefined") {
-      this.log.warn(
-        `WAR changedSpeed | ${this.model} | Speed was changed to ${speed}%, this speed is not supported`
-      );
+      this.log.warn(`WAR changedSpeed | ${this.model} | Speed was changed to ${speed}%, this speed is not supported`);
     } else {
       const { homekitTopLevel, name } = speedMode;
       if (isNewValue) {
-        this.log.info(
-          `INF changedSpeed | ${this.model} | Speed was changed to ${speed}% (${name}), for HomeKit ${homekitTopLevel}%`
-        );
+        this.log.info(`INF changedSpeed | ${this.model} | Speed was changed to ${speed}% (${name}), for HomeKit ${homekitTopLevel}%`);
       }
-      this.services.fan
-        .getCharacteristic(Characteristic.RotationSpeed)
-        .updateValue(homekitTopLevel);
+      this.services.fan.getCharacteristic(Characteristic.RotationSpeed).updateValue(homekitTopLevel);
     }
   }
 
   changedBattery(level) {
-    this.log.debug(
-      `DEB changedBattery | ${this.model} | BatteryLevel ${level}%`
-    );
-    this.services.battery
-      .getCharacteristic(Characteristic.BatteryLevel)
-      .updateValue(level);
-    this.services.battery
-      .getCharacteristic(Characteristic.StatusLowBattery)
-      .updateValue(
-        level < 20
-          ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
-          : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL
-      );
+    this.log.debug(`DEB changedBattery | ${this.model} | BatteryLevel ${level}%`);
+    this.services.battery.getCharacteristic(Characteristic.BatteryLevel).updateValue(level);
+    this.services.battery.getCharacteristic(Characteristic.StatusLowBattery).updateValue((level < 20) ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
   }
 
   async initializeDevice() {
-    this.log.debug("DEB getDevice | Discovering vacuum cleaner");
+    this.log.debug('DEB getDevice | Discovering vacuum cleaner');
 
     const device = await miio.device({
       address: this.config.ip,
       token: this.config.token,
     });
 
-    if (device.matches("type:vaccuum")) {
+    if (device.matches('type:vaccuum')) {
       this.device = device;
 
       this.model = this.device.miioModel;
       this.services.info.setCharacteristic(Characteristic.Model, this.model);
 
-      this.log.info("STA getDevice | Connected to: %s", this.config.ip);
-      this.log.info("STA getDevice | Model: " + this.device.miioModel);
-      this.log.info("STA getDevice | State: " + this.device.property("state"));
-      this.log.info(
-        "STA getDevice | FanSpeed: " + this.device.property("fanSpeed")
-      );
-      this.log.info(
-        "STA getDevice | BatteryLevel: " + this.device.property("batteryLevel")
-      );
+      this.log.info('STA getDevice | Connected to: %s', this.config.ip);
+      this.log.info('STA getDevice | Model: ' + this.device.miioModel);
+      this.log.info('STA getDevice | State: ' + this.device.property("state"));
+      this.log.info('STA getDevice | FanSpeed: ' + this.device.property("fanSpeed"));
+      this.log.info('STA getDevice | BatteryLevel: ' + this.device.property("batteryLevel"));
 
       if (this.config.autoroom) {
-        if (Array.isArray(this.config.autoroom)) {
-          await this.getRoomList();
-        } else {
-          await this.getRoomMap();
-        }
+        await this.getRoomMap();
       }
 
       try {
         const serial = await this.getSerialNumber();
-        this.services.info.setCharacteristic(
-          Characteristic.SerialNumber,
-          `${serial}`
-        );
+        this.services.info.setCharacteristic(Characteristic.SerialNumber, `${serial}`);
         this.log.info(`STA getDevice | Serialnumber: ${serial}`);
       } catch (err) {
         this.log.error(`ERR getDevice | get_serial_number | ${err}`);
@@ -593,69 +387,57 @@ class XiaomiRoborockVacuum {
       try {
         const firmware = await this.getFirmware();
         this.firmware = firmware;
-        this.services.info.setCharacteristic(
-          Characteristic.FirmwareRevision,
-          `${firmware}`
-        );
+        this.services.info.setCharacteristic(Characteristic.FirmwareRevision, `${firmware}`);
         this.log.info(`STA getDevice | Firmwareversion: ${firmware}`);
       } catch (err) {
         this.log.error(`ERR getDevice | miIO.info | ${err}`);
       }
+      //Changed by Mai
+      var minStep = this.findSpeedModes().speed.length == 6 ? 20 : 25;
+      this.log.info(`INF initializeDevice | ${this.model} ${this.firmware} | Setting the minimal step for fan service to ${minStep}.`);
+      this.services.fan
+        .getCharacteristic(Characteristic.RotationSpeed).setProps({
+          minStep: minStep
+        }).on('get', (cb) => callbackify(() => this.getSpeed(), cb))
+        .on('set', (newState, cb) => callbackify(() => this.setSpeed(newState), cb));
 
-      this.device.on("errorChanged", (error) => this.changedError(error));
-      this.device.on("stateChanged", (state) => {
-        if (state.key === "cleaning") {
+      this.device.on('errorChanged', (error) => this.changedError(error));
+      this.device.on('stateChanged', (state) => {
+        this.log.info(`INF stateChanged | ${this.model} | New state: ${state.key}=${state.value}`);
+        if (state.key === 'cleaning') {
           this.changedCleaning(state.value);
           this.changedPause(state.value);
-        } else if (state.key === "charging") {
+        } else if (state.key === 'charging') {
           this.changedCharging(state.value);
-        } else if (state.key === "fanSpeed") {
+        } else if (state.key === 'fanSpeed') {
           this.changedSpeed(state.value);
-        } else if (state.key === "batteryLevel") {
+        } else if (state.key === 'batteryLevel') {
           this.changedBattery(state.value);
         } else {
-          this.log.debug(
-            `DEB stateChanged | ${this.model} | Not supported stateChanged event: ${state.key}:${state.value}`
-          );
+          this.log.WARN(`WRN stateChanged | ${this.model} | Not supported stateChanged event: ${state.key}=${state.value}`);
         }
       });
-
-      // Now that we know the model, amend the steps in the Rotation speed (for better usability)
-      const minStep = 100 / (this.findSpeedModes().speed.length - 1);
-      this.services.fan
-        .getCharacteristic(Characteristic.RotationSpeed)
-        .setProps({ "minStep": minStep });
 
       await this.getState();
       // Refresh the state every 30s so miio maintains a fresh connection (or recovers connection if lost until we fix https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/81)
       clearInterval(this.getStateInterval);
-      this.getStateInterval = setInterval(
-        () => this.getState(),
-        GET_STATE_INTERVAL_MS
-      );
+      //Changed by Mai
+      this.getStateInterval = setInterval(() => this.device.poll(false), GET_STATE_INTERVAL_MS);
     } else {
       const model = (device || {}).miioModel;
-      this.log.error(
-        `ERR getDevice | Device "${model}" is not registered as a vacuum cleaner! If you think it should be, please open an issue at https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/new and provide this line.`
-      );
+      this.log.error(`ERR getDevice | Device "${model}" is not registered as a vacuum cleaner! If you think it should be, please open an issue at https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/new and provide this line.`);
       this.log.debug(device);
       device.destroy();
     }
   }
 
   async connect() {
-    if (this.connectingPromise === null) {
-      // if already trying to connect, don't trigger yet another one
+    if (this.connectingPromise === null) { // if already trying to connect, don't trigger yet another one
       this.connectingPromise = this.initializeDevice().catch((error) => {
-        this.log.error(
-          `ERR connect | miio.device, next try in 2 minutes | ${error}`
-        );
+        this.log.error(`ERR connect | miio.device, next try in 2 minutes | ${error}`);
         clearTimeout(this.connectRetry);
         // Using setTimeout instead of holding the promise. This way we'll keep retrying but not holding the other actions
-        this.connectRetry = setTimeout(
-          () => this.connect().catch(() => {}),
-          120000
-        );
+        this.connectRetry = setTimeout(() => this.connect().catch(() => { }), 120000);
         throw error;
       });
     }
@@ -678,17 +460,10 @@ class XiaomiRoborockVacuum {
       // checking if the device has an open socket it will fail retrieving it if not
       // https://github.com/aholstenson/miio/blob/master/lib/network.js#L227
       const socket = this.device.handle.api.parent.socket;
-      this.log.debug(
-        `DEB ensureDevice | ${this.model} | The socket is still on. Reusing it.`
-      );
+      this.log.debug(`DEB ensureDevice | ${this.model} | The socket is still on. Reusing it.`);
     } catch (err) {
-      if (
-        /destroyed/i.test(err.message) ||
-        /No vacuum cleaner is discovered yet/.test(err.message)
-      ) {
-        this.log.info(
-          `INF ensureDevice | ${this.model} | The socket was destroyed or not initialised, initialising the device`
-        );
+      if (/destroyed/i.test(err.message) || /No vacuum cleaner is discovered yet/.test(err.message)) {
+        this.log.info(`INF ensureDevice | ${this.model} | The socket was destroyed or not initialised, initialising the device`);
         await this.connect();
       } else {
         this.log.error(err);
@@ -699,21 +474,17 @@ class XiaomiRoborockVacuum {
 
   async getState() {
     try {
-      await this.ensureDevice("getState");
+      await this.ensureDevice('getState');
       const state = await this.device.state();
       this.log.debug(`DEB getState | ${this.model} | State %j`, state);
 
       safeCall(state.cleaning, (cleaning) => this.changedCleaning(cleaning));
       safeCall(state.charging, (charging) => this.changedCharging(charging));
       safeCall(state.fanSpeed, (fanSpeed) => this.changedSpeed(fanSpeed));
-      safeCall(state.batteryLevel, (batteryLevel) =>
-        this.changedBattery(batteryLevel)
-      );
+      safeCall(state.batteryLevel, (batteryLevel) => this.changedBattery(batteryLevel));
       safeCall(state.cleaning, (cleaning) => this.changedPause(cleaning));
       if (this.config.waterBox) {
-        safeCall(state["water_box_mode"], (waterBoxMode) =>
-          this.changedWaterSpeed(waterBoxMode)
-        );
+        safeCall(state['water_box_mode'], (waterBoxMode) => this.changedWaterSpeed(waterBoxMode));
       }
 
       // No need to throw the error at this point. This are just warnings like (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/91)
@@ -724,237 +495,227 @@ class XiaomiRoborockVacuum {
   }
 
   async getSerialNumber() {
-    await this.ensureDevice("getSerialNumber");
+    await this.ensureDevice('getSerialNumber');
 
     try {
-      const serial = await this.device.call("get_serial_number");
-      this.log.info(
-        `INF getSerialNumber | ${this.model} | Serial Number is ${serial[0].serial_number}`
-      );
+      const serial = await this.device.call('get_serial_number');
+      this.log.info(`INF getSerialNumber | ${this.model} | Serial Number is ${serial[0].serial_number}`);
 
       return serial[0].serial_number;
     } catch (err) {
-      this.log.error(
-        `ERR getSerialNumber | Failed getting the firmware version.`,
-        err
-      );
+      this.log.error(`ERR getSerialNumber | Failed getting the firmware version.`, err);
       throw err;
     }
   }
 
   async getFirmware() {
-    await this.ensureDevice("getFirmware");
+    await this.ensureDevice('getFirmware');
 
     try {
-      const firmware = await this.device.call("miIO.info");
-      this.log.info(
-        `INF getFirmware | ${this.model} | Firmwareversion is ${firmware.fw_ver}`
-      );
+      const firmware = await this.device.call('miIO.info');
+      this.log.info(`INF getFirmware | ${this.model} | Firmwareversion is ${firmware.fw_ver}`);
 
       return firmware.fw_ver;
     } catch (err) {
-      this.log.error(
-        `ERR getFirmware | Failed getting the firmware version.`,
-        err
-      );
+      this.log.error(`ERR getFirmware | Failed getting the firmware version.`, err);
       throw err;
     }
   }
 
   get isCleaning() {
-    const status = this.device.property("state");
+    const status = this.device.property('state');
     return XiaomiRoborockVacuum.cleaningStatuses.includes(status);
   }
 
+
+  get isGoingToTarget() {
+    const status = this.device.property('state');
+    return 'unknown-16' === status;
+  }
+
+
+
+  //Changed by Mai
+  get isInPause() {
+    const status = this.device.property('state');
+    return 'paused' === status;
+  }
+
+
   async getCleaning() {
+    await this.ensureDevice('getCleaning');
+
     try {
-      const isCleaning = this.isCleaning;
-      this.log.info(
-        `INF getCleaning | ${this.model} | Cleaning is ${isCleaning}`
-      );
+      const isCleaning = this.isCleaning
+      this.log.info(`INF getCleaning | ${this.model} | Cleaning is ${isCleaning}`);
 
       return isCleaning;
     } catch (err) {
-      this.log.error(
-        `ERR getCleaning | Failed getting the cleaning status.`,
-        err
-      );
+      this.log.error(`ERR getCleaning | Failed getting the cleaning status.`, err);
       throw err;
     }
   }
 
+  //Changed by Mai
   async setCleaning(state) {
-    await this.ensureDevice("setCleaning");
-
+    await this.ensureDevice('setCleaning');
+    this.log.info(`ACT setCleaning | ${this.model} | Set cleaning to ${state}}`);
     try {
-      if (state && !this.isCleaning) {
-        // Start cleaning
-        this.log.info(
-          `ACT setCleaning | ${this.model} | Start cleaning, not charging.`
-        );
-        await this.device.activateCleaning();
-      } else if (!state) {
-        // Stop cleaning
-        this.log.info(
-          `ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`
-        );
+      if (state && !this.isCleaning) { // Start cleaning
+        if (this.roomsToClean.length > 0) {
+          const refreshState = {
+            refresh: ['state'],
+            refreshDelay: 1000
+          };
+          await this.device.call('app_segment_clean', this.roomsToClean, refreshState);
+          this.log.info(`ACT setCleaning | ${this.model} | Start room cleaning for rooms ${this.roomsToClean}, the device is in state ${this.device.property('state')}`);
+
+        } else {
+          await this.device.activateCleaning();
+          this.log.info(`ACT setCleaning | ${this.model} | Start full cleaning, the device is in state ${this.device.property('state')}`);
+        }
+        return;
+      } else if (!state && (this.isCleaning || this.isInPause)) { // Stop cleaning
         await this.activateCharging(); // Charging works for 1st, not for 2nd
+        this.log.info(`ACT setCleaning | ${this.model} | Stop cleaning and go to charge, the device is in state ${this.device.property('state')}`);
+        //All rooms are removed from the list
+        this.roomsToClean.length = 0;
+        return;
       }
     } catch (err) {
-      this.log.error(
-        `ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`,
-        err
-      );
+      this.log.error(`ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`, err);
       throw err;
     }
+    this.log.error(`ERR setCleaning | ${this.model} |Cannot set cleaning to ${state} when current state is ${this.device.property('state')}!`);
+   // throw new Error('Cannot start or stop cleaning due to the current state!');
+
+  }
+  //Changed by Mai
+  async getCleaningRoom(room) {
+    await this.ensureDevice('getCleaningRoom');
+    return this.roomsToClean.includes(room);
   }
 
+  //Changed by Mai
   async setCleaningRoom(state, room) {
-    await this.ensureDevice("setCleaning");
+    await this.ensureDevice('setCleaning');
 
     try {
-      if (state && !this.isCleaning) {
-        // Start cleaning
-        this.log.info(
-          `ACT setCleaning | ${this.model} | Start cleaning Room ID ${room}, not charging.`
-        );
-        const refreshState = {
-          refresh: ["state"],
-          refreshDelay: 1000,
-        };
-        await this.device.call("app_segment_clean", [room], refreshState);
-      } else if (!state) {
-        // Stop cleaning
-        this.log.info(
-          `ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`
-        );
-        await this.activateCharging();
+      if (state && !this.isCleaning && !this.isInPause) {
+        this.log.info(`ACT setCleaning | ${this.model} | Add room ${room} to the list of rooms to be cleaned.`);
+        if (!this.roomsToClean.includes(room)) {
+          this.roomsToClean.push(room);
+        }
+        return;
+      } else if (!state && !this.isCleaning && !this.isInPause) {
+        this.log.info(`ACT setCleaning | ${this.model} | Remove room ${room} to the list of rooms to be cleaned.`);
+        if (this.roomsToClean.includes(room)) {
+          const index = this.roomsToClean.indexOf(room);
+          if (index > -1) {
+            this.roomsToClean.splice(index, 1);
+          }
+        }
+        return;
       }
     } catch (err) {
-      this.log.error(
-        `ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`,
-        err
-      );
+      this.log.error(`ERR setCleaning | ${this.model} | Failed to set cleaning to ${state} for room ${room}`, err);
       throw err;
+    }
+    this.log.warn(`WRN setCleaning | ${this.model} | Cannot set cleaning state ${state} for room ${room} when the robot is in state ${this.device.property('state')}`);
+    throw new Error(`WRN setCleaning | ${this.model} | Cannot set cleaning state ${state} for room ${room} when the robot is in state ${this.device.property('state')}`);
+  }
+
+  //Changed by Mai
+  async getGotoTarget() {
+    await this.ensureDevice('getGotoTarget');
+    this.log.info('INF getGotoTarget | ' + this.model + ' | Going to target ' + this.isGoingToTarget);
+    return this.isGoingToTarget;
+  }
+
+  //changed by Mai
+  async setGotoTarget(state, target) {
+    await this.ensureDevice('setGotoTarget');
+    this.log.info('INF | setGotoTarget | ' + this.model + ' | Go to target ' + target + ' is set to ' + state);
+    if (state) {
+      if (this.device.property('state') === 'charging' && this.config.gotoTarget) {
+        const refreshState = {
+          refresh: ['state'],
+          refreshDelay: 1000
+        };
+        await this.device.call('app_goto_target', target, refreshState);
+        this.log.info(`INF setGotoTarget | ${this.model} | Start going to target ${target}`);
+      } else {
+        this.log.warn('WARN | setGotoTarget | ' + this.model + ' | Device is not in charging state or target not defined.');
+        throw new Error('Device is not in charging state or target not defined.');
+      }
+    } else {
+      this.log.debug('DEB | setGotoTarget | ' + this.model + ' | Go back to charging station.');
+      if (this.device.property('state') === 'waiting') {
+        await this.activateCharging();
+        this.log.info(`INF setGotoTarget | ${this.model} | Going back to charging station`);
+      } else if (this.isGoingToTarget) {
+        const refreshState = {
+          refresh: ['state'],
+          refreshDelay: 1000
+        };
+        await this.device.call('app_pause', [], refreshState);
+        this.log.info(`INF setGotoTarget | ${this.model} | Pause going to target`);
+        await this.activateCharging();
+        this.log.info(`INF setGotoTarget | ${this.model} | Going back to charging station`);
+      }
+      else {
+        this.log.warn('WARN | setGotoTarget | ' + this.model + ' | Not able to return to dock because device is on the way to target.');
+        throw new Error('Not able to return to dock because device is on the way to target.');
+      }
     }
   }
 
   async setCleaningZone(state, zone) {
-    await this.ensureDevice("setCleaning");
+    await this.ensureDevice('setCleaning');
 
     try {
-      if (state && !this.isCleaning) {
-        // Start cleaning
-        this.log.info(
-          `ACT setCleaning | ${this.model} | Start cleaning Zone ${zone}, not charging.`
-        );
+      if (state && !this.isCleaning) { // Start cleaning
+        this.log.info(`ACT setCleaning | ${this.model} | Start cleaning Zone ${zone}, not charging.`);
         const refreshState = {
-          refresh: ["state"],
-          refreshDelay: 1000,
+          refresh: ['state'],
+          refreshDelay: 1000
         };
-
-        var zoneParams = [];
-        for (var zon of zone) {
-          if (zon.length == 4) {
-            zoneParams.push(zon.concat(1));
-          } else if (zon.length == 5) {
-            zoneParams.push(zon);
-          }
-        }
-        await this.device.call("app_zoned_clean", zoneParams, refreshState);
-      } else if (!state) {
-        // Stop cleaning
-        this.log.info(
-          `ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`
-        );
+        await this.device.call('app_zoned_clean', [zone], refreshState);
+      } else if (!state) { // Stop cleaning
+        this.log.info(`ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`);
         await this.activateCharging();
       }
     } catch (err) {
-      this.log.error(
-        `ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`,
-        err
-      );
+      this.log.error(`ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`, err);
       throw err;
     }
   }
 
   async activateCharging() {
-    await this.ensureDevice("activateCharging");
+    await this.ensureDevice('activateCharging');
     try {
       const refreshState = {
-        refresh: ["state"],
-        refreshDelay: 1000,
+        refresh: ['state'],
+        refreshDelay: 1000
       };
-      await this.device.call("app_stop", [], refreshState);
+      await this.device.call('app_stop', [], refreshState);
       // Wait one second before calling go to charge
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const changeResponse = await this.device.call(
-        "app_charge",
-        [],
-        refreshState
-      );
-      if (!(changeResponse && changeResponse[0] === "ok")) {
-        throw new Error("Failed to go to change");
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      const changeResponse = await this.device.call('app_charge', [], refreshState);
+      if (!(changeResponse && changeResponse[0] === 'ok')) {
+        throw new Error('Failed to go to change');
       }
     } catch (err) {
-      this.log.error(
-        `ERR setCharging | ${this.model} | Failed to go charging.`,
-        err
-      );
-      throw err;
-    }
-  }
-
-  async getRoomList() {
-    await this.ensureDevice("getRoomList");
-
-    try {
-      const timers = await this.device.call("get_timer");
-
-      // Find specific timer containing the room order
-      // Timer needs to be scheduled for 00:00 and inactive
-      let leetTimer = timers.find(
-        (x) => x[2][0].startsWith("0 0") && x[1] == "off"
-      );
-      if (leetTimer == undefined) {
-        this.log.error(
-          `ERR getRoomList | ${this.model} | Could not find a timer for autoroom`
-        );
-        return;
-      }
-
-      let roomIds = leetTimer[2][1][1]["segments"].split(`,`).map((x) => +x);
-      this.log.debug(
-        `DEB getRoomList | ${this.model} | Room IDs are ${roomIds}`
-      );
-
-      if (roomIds.length != this.config.autoroom.length) {
-        this.log.error(
-          `ERR getRoomList | ${this.model} | Number of rooms in config does not match number of rooms in the timer`
-        );
-        return;
-      }
-      let roomMap = [];
-      for (const [i, roomId] of roomIds.entries()) {
-        this.services[this.config.autoroom[i]].roomId = roomId;
-        roomMap.push({ id: roomId, name: this.config.autoroom[i] });
-      }
-      this.log.info(
-        `INF getRoomList | ${this.model} | Created "rooms": ${JSON.stringify(
-          roomMap
-        )}`
-      );
-    } catch (err) {
-      this.log.error(`ERR getRoomList | Failed getting the Room List.`, err);
+      this.log.error(`ERR setCharging | ${this.model} | Failed to go charging.`, err);
       throw err;
     }
   }
 
   async getRoomMap() {
-    await this.ensureDevice("getRoomMap");
+    await this.ensureDevice('getRoomMap');
 
     try {
-      const map = await this.device.call("get_room_mapping");
+      const map = await this.device.call('get_room_mapping');
       this.log.info(`INF getRoomMap | ${this.model} | Map is ${map}`);
       for (let val of map) {
         this.createRoom(val[0], val[1]);
@@ -966,43 +727,25 @@ class XiaomiRoborockVacuum {
   }
 
   createRoom(roomId, roomName) {
-    this.log.info(
-      `INF createRoom | ${this.model} | Room ${roomName} (${roomId})`
-    );
-    this.services[roomName] = new Service.Switch(
-      `${this.config.cleanword} ${roomName}`,
-      "roomService" + roomId
-    );
-    this.services[roomName].roomId = roomId;
+    this.log.info(`INF createRoom | ${this.model} | Room ${roomName} (${roomId})`);
+    this.services[roomName] = new Service.Switch(`${this.config.cleanword} ${roomName}`, 'roomService' + roomId);
     this.services[roomName]
       .getCharacteristic(Characteristic.On)
-      .on("get", (cb) => callbackify(() => this.getCleaning(), cb))
-      .on("set", (newState, cb) =>
-        callbackify(
-          () => this.setCleaningRoom(newState, this.services[roomName].roomId),
-          cb
-        )
-      )
-      .on("change", (oldState, newState) => {
+      .on('get', (cb) => callbackify(() => this.getCleaningRoom(roomId), cb))
+      .on('set', (newState, cb) => callbackify(() => this.setCleaningRoom(newState, roomId), cb))
+      .on('change', (oldState, newState) => {
         this.changedPause(newState);
       });
   }
 
   createZone(zoneName, zoneParams) {
-    this.log.info(
-      `INF createRoom | ${this.model} | Zone ${zoneName} (${zoneParams})`
-    );
-    this.services[zoneName] = new Service.Switch(
-      `${this.config.cleanword} ${zoneName}`,
-      "zoneCleaning" + zoneName
-    );
+    this.log.info(`INF createRoom | ${this.model} | Zone ${zoneName} (${zoneParams})`);
+    this.services[zoneName] = new Service.Switch(`${this.config.cleanword} ${zoneName}`, 'zoneCleaning' + zoneName);
     this.services[zoneName]
       .getCharacteristic(Characteristic.On)
-      .on("get", (cb) => callbackify(() => this.getCleaning(), cb))
-      .on("set", (newState, cb) =>
-        callbackify(() => this.setCleaningZone(newState, zoneParams), cb)
-      )
-      .on("change", (oldState, newState) => {
+      .on('get', (cb) => callbackify(() => this.getCleaning(), cb))
+      .on('set', (newState, cb) => callbackify(() => this.setCleaningZone(newState, zoneParams), cb))
+      .on('change', (oldState, newState) => {
         this.changedPause(newState);
       });
   }
@@ -1010,8 +753,7 @@ class XiaomiRoborockVacuum {
   findSpeedModes() {
     return (MODELS[this.model] || []).reduce((acc, option) => {
       if (option.firmware) {
-        const [, cleanFirmware] =
-          (this.firmware || "").match(/^(\d+\.\d+\.\d+)/) || [];
+        const [, cleanFirmware] = (this.firmware || '').match(/^(\d+\.\d+\.\d+)/) || [];
         return semver.satisfies(cleanFirmware, option.firmware) ? option : acc;
       } else {
         return option;
@@ -1028,48 +770,35 @@ class XiaomiRoborockVacuum {
   }
 
   async getSpeed() {
-    const speed = this.device.property("fanSpeed");
-    this.log.info(
-      `INF getSpeed | ${this.model} | Fanspeed is ${speed} over miIO. Converting to HomeKit`
-    );
+    await this.ensureDevice('getSpeed');
+
+    const speed = this.device.property('fanSpeed');
+    this.log.debug(`DEB getSpeed | ${this.model} | Fanspeed is ${speed} over miIO. Converting to HomeKit`)
 
     const { homekitTopLevel, name } = this.findSpeedModeFromMiio(speed);
 
-    this.log.info(
-      `INF getSpeed | ${this.model} | Fanspeed is ${speed} over miIO "${name}" > HomeKit speed ${homekitTopLevel}%`
-    );
+    this.log.info(`INF getSpeed | ${this.model} | Fanspeed is ${speed} over miIO "${name}" > HomeKit speed ${homekitTopLevel}%`);
     return homekitTopLevel || 0;
   }
 
   async setSpeed(speed) {
-    await this.ensureDevice("setSpeed");
+    await this.ensureDevice('setSpeed');
 
-    this.log.debug(
-      `ACT setSpeed | ${this.model} | Speed got ${speed}% over HomeKit > CLEANUP.`
-    );
+    this.log.debug(`ACT setSpeed | ${this.model} | Speed got ${speed}% over HomeKit > CLEANUP.`);
 
     // Get the speed modes for this model
     const speedModes = this.findSpeedModes().speed;
 
     // gen1 has maximum of 91%, so anything over that won't work. Getting safety maximum.
-    const safeSpeed = Math.min(
-      parseInt(speed),
-      speedModes[speedModes.length - 1].homekitTopLevel
-    );
+    const safeSpeed = Math.min(parseInt(speed), speedModes[speedModes.length - 1].homekitTopLevel);
 
     // Find the minimum homekitTopLevel that matches the desired speed
-    const { miLevel, name } = speedModes.find(
-      (mode) => safeSpeed <= mode.homekitTopLevel
-    );
+    const { miLevel, name } = speedModes.find((mode) => safeSpeed <= mode.homekitTopLevel);
 
-    this.log.info(
-      `ACT setSpeed | ${this.model} | FanSpeed set to ${miLevel} over miIO for "${name}".`
-    );
+    this.log.info(`ACT setSpeed | ${this.model} | FanSpeed set to ${miLevel} over miIO for "${name}".`);
 
     if (miLevel === 0) {
-      this.log.debug(
-        `DEB setSpeed | ${this.model} | FanSpeed is 0 => Calling setCleaning(false) instead of changing the fan speed`
-      );
+      this.log.debug(`DEB setSpeed | ${this.model} | FanSpeed is 0 => Calling setCleaning(false) instead of changing the fan speed`);
       await this.setCleaning(false);
     } else {
       await this.device.changeFanSpeed(miLevel);
@@ -1086,9 +815,7 @@ class XiaomiRoborockVacuum {
 
   async getWaterSpeedInDevice() {
     // From https://github.com/marcelrv/XiaomiRobotVacuumProtocol/blob/master/water_box_custom_mode.md
-    const response = await this.device.call("get_water_box_custom_mode", [], {
-      refresh: ["water_box_mode"],
-    });
+    const response = await this.device.call('get_water_box_custom_mode', [], { refresh: ['water_box_mode'] });
     // From https://github.com/nicoh88/miio/blob/master/lib/devices/vacuum.js#L11-L18
     const [waterMode] = response || [];
     if (typeof waterMode === undefined) {
@@ -1099,180 +826,152 @@ class XiaomiRoborockVacuum {
   }
 
   async getWaterSpeed() {
-    await this.ensureDevice("getWaterSpeed");
+    await this.ensureDevice('getWaterSpeed');
+
 
     const speed = await this.getWaterSpeedInDevice();
-    this.log.info(
-      `INF getWaterSpeed | ${this.model} | WaterBoxMode is ${speed} over miIO. Converting to HomeKit`
-    );
+    this.log.info(`INF getWaterSpeed | ${this.model} | WaterBoxMode is ${speed} over miIO. Converting to HomeKit`)
 
     const waterSpeed = this.findWaterSpeedModeFromMiio(speed);
 
-    let homekitValue = 0;
+    let homekitValue = 0
     if (waterSpeed) {
-      const { homekitTopLevel, name } = waterSpeed;
-      this.log.info(
-        `INF getWaterSpeed | ${this.model} | WaterBoxMode is ${speed} over miIO "${name}" > HomeKit speed ${homekitTopLevel}%`
-      );
+      const { homekitTopLevel, name } = waterSpeed
+      this.log.info(`INF getWaterSpeed | ${this.model} | WaterBoxMode is ${speed} over miIO "${name}" > HomeKit speed ${homekitTopLevel}%`);
       homekitValue = homekitTopLevel || 0;
     }
-    this.services.waterBox
-      .getCharacteristic(Characteristic.On)
-      .updateValue(homekitValue > 0);
+    this.services.waterBox.getCharacteristic(Characteristic.On).updateValue(homekitValue > 0);
     return homekitValue;
   }
 
   async setWaterSpeed(speed) {
-    await this.ensureDevice("setWaterSpeed");
+    await this.ensureDevice('setWaterSpeed');
 
-    this.log.debug(
-      `ACT setWaterSpeed | ${this.model} | Speed got ${speed}% over HomeKit > CLEANUP.`
-    );
+    this.log.debug(`ACT setWaterSpeed | ${this.model} | Speed got ${speed}% over HomeKit > CLEANUP.`);
 
     // Get the speed modes for this model
     const speedModes = this.findSpeedModes().waterspeed || [];
 
     // If the robot does not support water-mode cleaning
     if (speedModes.length === 0) {
-      this.log.info(
-        `INF setWaterSpeed | ${this.model} | Model does not support the water mode`
-      );
+      this.log.info(`INF setWaterSpeed | ${this.model} | Model does not support the water mode`);
       return;
     }
 
     // gen1 has maximum of 91%, so anything over that won't work. Getting safety maximum.
-    const safeSpeed = Math.min(
-      parseInt(speed),
-      speedModes[speedModes.length - 1].homekitTopLevel
-    );
+    const safeSpeed = Math.min(parseInt(speed), speedModes[speedModes.length - 1].homekitTopLevel);
 
     // Find the minimum homekitTopLevel that matches the desired speed
-    const { miLevel, name } = speedModes.find(
-      (mode) => safeSpeed <= mode.homekitTopLevel
-    );
+    const { miLevel, name } = speedModes.find((mode) => safeSpeed <= mode.homekitTopLevel);
 
-    this.log.info(
-      `ACT setWaterSpeed | ${this.model} | WaterBoxMode set to ${miLevel} over miIO for "${name}".`
-    );
+    this.log.info(`ACT setWaterSpeed | ${this.model} | WaterBoxMode set to ${miLevel} over miIO for "${name}".`);
 
     // From https://github.com/marcelrv/XiaomiRobotVacuumProtocol/blob/master/water_box_custom_mode.md
-    const response = await this.device.call(
-      "set_water_box_custom_mode",
-      [miLevel],
-      { refresh: ["water_box_mode"] }
-    );
+    const response = await this.device.call('set_water_box_custom_mode', [miLevel], { refresh: ['water_box_mode'] });
     // From https://github.com/nicoh88/miio/blob/master/lib/devices/vacuum.js#L11-L18
-    if (response !== 0 && response[0] !== "ok") {
+    if (response !== 0 && response[0] !== 'ok') {
       this.log.error(response);
       throw new Error(`Failed to set the water_box_mode to ${miLevel}`);
     }
   }
 
   changedWaterSpeed(speed) {
-    this.log.info(
-      `MON changedWaterSpeed | ${this.model} | WaterBoxMode is now ${speed}%`
-    );
+    this.log.info(`MON changedWaterSpeed | ${this.model} | WaterBoxMode is now ${speed}%`);
 
     const speedMode = this.findWaterSpeedModeFromMiio(speed);
 
     if (typeof speedMode === "undefined") {
-      this.log.warn(
-        `WAR changedWaterSpeed | ${this.model} | Speed was changed to ${speed}%, this speed is not supported`
-      );
+      this.log.warn(`WAR changedWaterSpeed | ${this.model} | Speed was changed to ${speed}%, this speed is not supported`);
     } else {
       const { homekitTopLevel, name } = speedMode;
-      this.log.info(
-        `INF changedWaterSpeed | ${this.model} | Speed was changed to ${speed}% (${name}), for HomeKit ${homekitTopLevel}%`
-      );
-      this.services.waterBox
-        .getCharacteristic(Characteristic.RotationSpeed)
-        .updateValue(homekitTopLevel);
-      this.services.waterBox
-        .getCharacteristic(Characteristic.On)
-        .updateValue(homekitTopLevel > 0);
+      this.log.info(`INF changedWaterSpeed | ${this.model} | Speed was changed to ${speed}% (${name}), for HomeKit ${homekitTopLevel}%`);
+      this.services.waterBox.getCharacteristic(Characteristic.RotationSpeed).updateValue(homekitTopLevel);
+      this.services.waterBox.getCharacteristic(Characteristic.On).updateValue(homekitTopLevel > 0)
     }
   }
 
   async getPauseState() {
-    await this.ensureDevice("getPauseState");
+    await this.ensureDevice('getPauseState');
 
     try {
-      const isCleaning = this.isCleaning;
-      this.log.info(
-        `INF getPauseState | ${this.model} | Pause possible is ${isCleaning}`
-      );
+      const isCleaning = this.isCleaning
+      this.log.info(`INF getPauseState | ${this.model} | Pause possible is ${isCleaning}`);
       return isCleaning;
     } catch (err) {
-      this.log.error(
-        `ERR getPauseState | ${this.model} | Failed getting the cleaning status.`,
-        err
-      );
+      this.log.error(`ERR getPauseState | ${this.model} | Failed getting the cleaning status.`, err);
     }
   }
-
+  //Method changed by Mai
   async setPauseState(state) {
-    await this.ensureDevice("setPauseState");
-
+    await this.ensureDevice('setPauseState');
     try {
-      if (state) {
-        await this.device.activateCleaning();
-      } else {
-        await this.device.pause();
+      if (state && this.isInPause) {
+        if (this.roomsToClean.length > 0) {
+          const refreshState = {
+            refresh: ['state'],
+            refreshDelay: 1000
+          };
+          await this.device.call('resume_segment_clean', [], refreshState);
+          this.log.info(`INF setPauseState | Resume room cleaning, and the device is in state  ${this.device.property('state')}`);
+        } else {
+          await this.device.activateCleaning();
+          this.log.info(`INF setPauseState | Resume normal cleaning, and the device is in state  ${this.device.property('state')}`);
+        }
+        return;
+      } else if (!state && this.isCleaning) {
+        const refreshState = {
+          refresh: ['state'],
+          refreshDelay: 1000
+        };
+        await this.device.call('app_pause', [], refreshState);
+        this.log.info(`INF setPauseState | Sent pause command to the robot, and the device is in state ${this.device.property('state')}`);
+        return;
       }
     } catch (err) {
-      this.log.error(
-        `ERR setPauseState | ${this.model} | Failed updating pause state ${state}.`,
-        err
-      );
+      this.log.error(`ERR setPauseState | ${this.model} | Failed updating pause state ${state}.`, err);
     }
+    this.log.error(`ERR setPauseState | Cannot set pause state to ${state} due to current state ${this.device.property('state')}!`);
+    throw new Error('Cannot set pause state to  due to current state!');
   }
 
   async getCharging() {
-    const status = this.device.property("state");
-    this.log.info(
-      `INF getCharging | ${this.model} | Charging is ${
-        status === "charging"
-      } (Status is ${status})`
-    );
+    await this.ensureDevice('getCharging');
 
-    return status === "charging"
-      ? Characteristic.ChargingState.CHARGING
-      : Characteristic.ChargingState.NOT_CHARGING;
+    // From https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L65
+    const status = this.device.property('state');
+    this.log.info(`INF getCharging | ${this.model} | Charging is ${status === "charging"} (Status is ${status})`);
+
+    return (status === "charging") ? Characteristic.ChargingState.CHARGING : Characteristic.ChargingState.NOT_CHARGING;
   }
 
   async getDocked() {
-    const status = this.device.property("state");
-    this.log.info(
-      `INF getDocked | ${this.model} | Robot Docked is ${
-        status === "charging"
-      } (Status is ${status})`
-    );
+    await this.ensureDevice('getDocked');
+
+    // From https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L65
+    const status = this.device.property('state');
+    this.log.info(`INF getDocked | ${this.model} | Robot Docked is ${status === 'charging'} (Status is ${status})`);
 
     return status === "charging";
   }
 
   async getBattery() {
-    this.log.info(
-      `INF getBattery | ${this.model} | Batterylevel is ${this.device.property(
-        "batteryLevel"
-      )}%`
-    );
-    return this.device.property("batteryLevel");
+    await this.ensureDevice('getBattery');
+
+    // https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L90
+    this.log.info(`INF getBattery | ${this.model} | Batterylevel is ${this.device.property('batteryLevel')}%`);
+    return this.device.property('batteryLevel');
   }
 
   async getBatteryLow() {
-    this.log.info(
-      `INF getBatteryLow | ${
-        this.model
-      } | Batterylevel is ${this.device.property("batteryLevel")}%`
-    );
-    return this.device.property("batteryLevel") < 20
-      ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
-      : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
+    await this.ensureDevice('getBatteryLow');
+
+    // https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L90
+    this.log.info(`INF getBatteryLow | ${this.model} | Batterylevel is ${this.device.property('batteryLevel')}%`);
+    return (this.device.property('batteryLevel') < 20) ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
   }
 
   async identify(callback) {
-    await this.ensureDevice("identify");
+    await this.ensureDevice('identify');
 
     this.log.info(`ACT identify | ${this.model} | Find me - Hello!`);
     try {
@@ -1285,84 +984,50 @@ class XiaomiRoborockVacuum {
   }
 
   getServices() {
-    if (this.config.delay) this.sleep(5000);
+    if (this.config.delay)
+      sleep(5000);
     this.log.debug(`DEB getServices | ${this.model}`);
-    return Object.keys(this.services).map((key) => {
-      if (key !== "fan" && this.services.fan.addLinkedService) {
-        this.services.fan.addLinkedService(this.services[key]);
-      }
-      return this.services[key];
-    });
-  }
-
-  sleep(time) {
-    if (sleep) {
-      sleep(time);
-    } else {
-      this.log
-        .warn(`Can't use the delay option because the module "system-sleep" failed to install.\n
-      Make sure this optional dependency is properly installed if you want to use the "delay" option.`);
-    }
+    return Object.keys(this.services).map((key) => this.services[key]);
   }
 
   // CONSUMABLE / CARE
   async getCareSensors() {
+    await this.ensureDevice('getCareSensors');
+
     // 30h = sensor_dirty_time
     const lifetime = 108000;
-    const lifetimepercent =
-      (this.device.property("sensorDirtyTime") / lifetime) * 100;
-    this.log.info(
-      `INF getCareSensors | ${
-        this.model
-      } | Sensors dirtytime is ${this.device.property(
-        "sensorDirtyTime"
-      )} seconds / ${lifetimepercent.toFixed(2)}%.`
-    );
+    const lifetimepercent = this.device.property("sensorDirtyTime") / lifetime * 100;
+    this.log.info(`INF getCareSensors | ${this.model} | Sensors dirtytime is ${this.device.property("sensorDirtyTime")} seconds / ${lifetimepercent.toFixed(2)}%.`);
     return lifetimepercent;
   }
 
   async getCareFilter() {
+    await this.ensureDevice('getCareFilter');
+
     // 150h = filter_work_time
     const lifetime = 540000;
-    const lifetimepercent =
-      (this.device.property("filterWorkTime") / lifetime) * 100;
-    this.log.info(
-      `INF getCareFilter | ${
-        this.model
-      } | Filter worktime is ${this.device.property(
-        "filterWorkTime"
-      )} seconds / ${lifetimepercent.toFixed(2)}%.`
-    );
+    const lifetimepercent = this.device.property("filterWorkTime") / lifetime * 100;
+    this.log.info(`INF getCareFilter | ${this.model} | Filter worktime is ${this.device.property("filterWorkTime")} seconds / ${lifetimepercent.toFixed(2)}%.`);
     return lifetimepercent;
   }
 
   async getCareSideBrush() {
+    await this.ensureDevice('getCareSideBrush');
+
     // 200h = side_brush_work_time
     const lifetime = 720000;
-    const lifetimepercent =
-      (this.device.property("sideBrushWorkTime") / lifetime) * 100;
-    this.log.info(
-      `INF getCareSideBrush | ${
-        this.model
-      } | Sidebrush worktime is ${this.device.property(
-        "sideBrushWorkTime"
-      )} seconds / ${lifetimepercent.toFixed(2)}%.`
-    );
+    const lifetimepercent = this.device.property("sideBrushWorkTime") / lifetime * 100;
+    this.log.info(`INF getCareSideBrush | ${this.model} | Sidebrush worktime is ${this.device.property("sideBrushWorkTime")} seconds / ${lifetimepercent.toFixed(2)}%.`);
     return lifetimepercent;
   }
 
   async getCareMainBrush() {
+    await this.ensureDevice('getCareMainBrush');
+
     // 300h = main_brush_work_time
     const lifetime = 1080000;
-    const lifetimepercent =
-      (this.device.property("mainBrushWorkTime") / lifetime) * 100;
-    this.log.info(
-      `INF getCareMainBrush | ${
-        this.model
-      } | Mainbrush worktime is ${this.device.property(
-        "mainBrushWorkTime"
-      )} seconds / ${lifetimepercent.toFixed(2)}%.`
-    );
+    const lifetimepercent = this.device.property("mainBrushWorkTime") / lifetime * 100;
+    this.log.info(`INF getCareMainBrush | ${this.model} | Mainbrush worktime is ${this.device.property("mainBrushWorkTime")} seconds / ${lifetimepercent.toFixed(2)}%.`);
     return lifetimepercent;
   }
 }

--- a/lib/callbackify.js
+++ b/lib/callbackify.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 module.exports = async function (fn, callback) {
   try {
@@ -7,4 +7,4 @@ module.exports = async function (fn, callback) {
   } catch (err) {
     callback(err);
   }
-};
+}

--- a/lib/safeCall.js
+++ b/lib/safeCall.js
@@ -1,13 +1,13 @@
-"use strict";
+'use strict';
 
 /**
  * Calls the function `fn` if `maybeValue` is not undefined
- *
+ * 
  * @param maybeValue The value that can be undefined
  * @param fn The function to be called with the value as a parameter
  */
 module.exports = async function (maybeValue, fn) {
-  if (typeof maybeValue !== "undefined") {
+  if (typeof maybeValue !== 'undefined') {
     return fn(maybeValue);
   }
-};
+}

--- a/models/index.js
+++ b/models/index.js
@@ -1,3 +1,3 @@
-"use strict";
+'use strict';
 
-module.exports = require("./models");
+module.exports = require('./models');

--- a/models/models.js
+++ b/models/models.js
@@ -1,23 +1,21 @@
-"use strict";
+'use strict';
 
-const speedmodes = require("./speedmodes");
-const watermodes = require("./watermodes");
+const speedmodes = require('./speedmodes');
+const watermodes = require('./watermodes');
 
 module.exports = {
-  default: { speed: speedmodes.gen1 },
-  "rockrobo.vacuum.v1": [{ speed: speedmodes.gen2 }],
-  "roborock.vacuum.c1": [{ speed: speedmodes.gen1 }],
-  "roborock.vacuum.m1s": [{ speed: speedmodes.gen3 }],
-  "roborock.vacuum.s5": [
-    { speed: speedmodes.gen2 },
-    { firmware: ">=3.5.7", speed: speedmodes.gen3 },
+  'default': {speed: speedmodes.gen1},
+  'rockrobo.vacuum.v1': [{speed: speedmodes.gen1}],
+  'roborock.vacuum.c1': [{speed: speedmodes.gen1}],
+  'roborock.vacuum.m1s': [{speed: speedmodes.gen3}],
+  'roborock.vacuum.s5': [
+    {speed: speedmodes.gen2},
+    //Changed by Mai
+    {firmware: '>=3.5.7', speed: speedmodes.gen4},
   ],
-  "roborock.vacuum.s5e": [
-    { speed: speedmodes["gen4+custom"], waterspeed: watermodes.gen1 },
-  ],
-  "roborock.vacuum.s6": [{ speed: speedmodes.gen4 }],
-  "roborock.vacuum.t6": [{ speed: speedmodes.gen3 }],
-  "roborock.vacuum.t4": [{ speed: speedmodes.gen3 }],
-  "roborock.vacuum.e2": [{ speed: speedmodes["xiaowa-e202-02"] }],
-  "roborock.vacuum.a08": [{ speed: speedmodes.gen3 }],
+  'roborock.vacuum.s5e': [{speed: speedmodes.gen4, waterspeed: watermodes.gen1}],
+  'roborock.vacuum.s6': [{speed: speedmodes.gen3}],
+  'roborock.vacuum.t6': [{speed: speedmodes.gen3}],
+  'roborock.vacuum.t4': [{speed: speedmodes.gen3}],
+  'roborock.vacuum.e2': [{speed: speedmodes.gen3}],
 };

--- a/models/speedmodes.js
+++ b/models/speedmodes.js
@@ -1,118 +1,57 @@
-"use strict";
+'use strict';
 
-const SPEEDMODES = {
+module.exports = {
   gen1: [
-    // 0%      = Off / Aus
-    { miLevel: 0, name: "Off" },
-    // 0-25%  = "Quiet / Leise"
-    { miLevel: 38, name: "Quiet" },
-    // 26-50%  = "Balanced / Standard"
-    { miLevel: 60, name: "Balanced" },
-    // 51-75%  = "Turbo / Stark"
-    { miLevel: 77, name: "Turbo" },
-    // 76-100% = "Full Speed / Max Speed / Max"
-    { miLevel: 90, name: "Max" },
+    // 0%       = Off / Aus
+    { homekitTopLevel: 0, miLevel: 0, name: "Off" },
+    // 1-38%   = "Quiet / Leise"
+    { homekitTopLevel: 25, miLevel: 38, name: "Quiet" },
+    // 39-60%  = "Balanced / Standard"
+    { homekitTopLevel: 50, miLevel: 60, name: "Balanced" },
+    // 61-77%  = "Turbo / Stark"
+    { homekitTopLevel: 75, miLevel: 77, name: "Turbo" },
+    // 78-100% = "Full Speed / Max Speed / Max"
+    { homekitTopLevel: 100, miLevel: 90, name: "Max" }
   ],
   gen2: [
     // 0%      = Off / Aus
-    { miLevel: 0, name: "Off" },
-    // 1-20%   = "Mop / Mopping / Nur wischen"
-    { miLevel: 105, name: "Mop" },
-    // 21-40%  = "Quiet / Leise"
-    { miLevel: 38, name: "Quiet" },
-    // 41-60%  = "Balanced / Standard"
-    { miLevel: 60, name: "Balanced" },
-    // 61-80%  = "Turbo / Stark"
-    { miLevel: 75, name: "Turbo" },
-    // 81-100% = "Full Speed / Max Speed / Max"
-    { miLevel: 100, name: "Max" },
+    { homekitTopLevel: 0, miLevel: 0, name: "Off" },
+    // 1-15%   = "Mop / Mopping / Nur wischen"
+    { homekitTopLevel: 20, miLevel: 105, name: "Mop" },
+    // 16-38%  = "Quiet / Leise"
+    { homekitTopLevel: 40, miLevel: 38, name: "Quiet" },
+    // 39-60%  = "Balanced / Standard"
+    { homekitTopLevel: 60, miLevel: 60, name: "Balanced" },
+    // 61-75%  = "Turbo / Stark"
+    { homekitTopLevel: 80, miLevel: 75, name: "Turbo" },
+    // 76-100% = "Full Speed / Max Speed / Max"
+    { homekitTopLevel: 100, miLevel: 100, name: "Max" }
   ],
-  "xiaowa-e202-02": [
-    // 0%      = Off / Aus
-    { miLevel: 0, name: "Off" },
-    // 0-20%  = "Gentle"
-    { miLevel: 41, name: "Gentle" },
-    // 20-40%  = "Silent"
-    { miLevel: 50, name: "Silent" },
-    // 40-60%  = "Balanced / Standard"
-    { miLevel: 68, name: "Balanced" },
-    // 60-80%  = "Turbo / Stark"
-    { miLevel: 79, name: "Turbo" },
-    // 80-100% = "Full Speed / Max Speed / Max"
-    { miLevel: 100, name: "Max" }
-  ],  
   gen3: [
     // 0%      = Off / Aus
-    { miLevel: 0, name: "Off" },
-    // 1-25%   = "Quiet / Leise"
-    { miLevel: 101, name: "Quiet" },
-    // 26-50%  = "Balanced / Standard"
-    { miLevel: 102, name: "Balanced" },
-    // 51-75%  = "Turbo / Stark"
-    { miLevel: 103, name: "Turbo" },
-    // 76-100% = "Full Speed / Max Speed / Max"
-    { miLevel: 104, name: "Max" },
+    { homekitTopLevel: 0, miLevel: 0, name: "Off" },
+    // 1-38%   = "Quiet / Leise"
+    { homekitTopLevel: 25, miLevel: 101, name: "Quiet" },
+    // 39-60%  = "Balanced / Standard"
+    { homekitTopLevel: 50, miLevel: 102, name: "Balanced" },
+    // 61-77%  = "Turbo / Stark"
+    { homekitTopLevel: 75, miLevel: 103, name: "Turbo" },
+    // 78-100% = "Full Speed / Max Speed / Max"
+    { homekitTopLevel: 100, miLevel: 104, name: "Max" }
   ],
   // S5-Max (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/79#issuecomment-576246934)
-  gen4: [
+  gen4: [ 
     // 0%      = Off / Aus
-    { miLevel: 0, name: "Off" },
-    // 1-20%   = "Soft"
-    { miLevel: 105, name: "Soft" },
-    // 21-40%   = "Quiet / Leise"
-    { miLevel: 101, name: "Quiet" },
-    // 41-60%  = "Balanced / Standard"
-    { miLevel: 102, name: "Balanced" },
-    // 61-80%  = "Turbo / Stark"
-    { miLevel: 103, name: "Turbo" },
-    // 81-100% = "Full Speed / Max Speed / Max"
-    { miLevel: 104, name: "Max" },
-  ],
-  // S5-Max + Custom (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/110)
-  "gen4+custom": [
-    // 0%      = Off / Aus
-    { miLevel: 0, name: "Off" },
-    // 1-16%   = "Soft"
-    { miLevel: 105, name: "Soft" },
-    // 17-32%   = "Quiet / Leise"
-    { miLevel: 101, name: "Quiet" },
-    // 33-48%  = "Balanced / Standard"
-    { miLevel: 102, name: "Balanced" },
-    // 49-64%  = "Turbo / Stark"
-    { miLevel: 103, name: "Turbo" },
-    // 65-80% = "Full Speed / Max Speed / Max"
-    { miLevel: 104, name: "Max" },
-    // 81-100% = "Custom"
-    { miLevel: 106, name: "Custom" },
-  ],
+    { homekitTopLevel: 0, miLevel: 0, name: "Off" },
+    // 1-15%   = "Soft"
+    { homekitTopLevel: 20, miLevel: 105, name: "Soft" },
+    // 16-38%   = "Quiet / Leise"
+    { homekitTopLevel: 40, miLevel: 101, name: "Quiet" },
+    // 39-60%  = "Balanced / Standard"
+    { homekitTopLevel: 60, miLevel: 102, name: "Balanced" },
+    // 61-77%  = "Turbo / Stark"
+    { homekitTopLevel: 80, miLevel: 103, name: "Turbo" },
+    // 78-100% = "Full Speed / Max Speed / Max"
+    { homekitTopLevel: 100, miLevel: 104, name: "Max" }
+  ]
 };
-
-/**
- * Loops through all the speedmodes and assigns the `homekitTopLevel` with proportional steps.
- *
- * i.e.:
- * - If 5 possible states => 0%, 25%, 50%, 75% and 100%
- * - If 6 possible states => 0%, 20%, 40%, 60%, 80% and 100%
- * - If 7 possible states => 0%, 16%, 32%, 48%, 64%, 80% and 96%
- *
- * @returns object The SPEEDMODES + the addition of the `homekitTopLevel` property to each entry
- */
-function autoAssignHomekitTopLevel() {
-  const generations = Object.keys(SPEEDMODES);
-  return generations.reduce((acc, gen) => {
-    const speedmodes = SPEEDMODES[gen].map((mode, index, modes) => {
-      const step = Math.floor(100 / (modes.length - 1));
-      return Object.assign(
-        {},
-        {
-          // if it's the last element, max it out to 100%
-          homekitTopLevel: index === modes.length - 1 ? 100 : index * step,
-        },
-        mode // set later should we want to overwrite this logic in the SPEEDMODES definition
-      );
-    });
-    return Object.assign({}, acc, { [gen]: speedmodes });
-  }, {});
-}
-
-module.exports = autoAssignHomekitTopLevel();

--- a/models/watermodes.js
+++ b/models/watermodes.js
@@ -1,8 +1,8 @@
-"use strict";
+'use strict';
 
 module.exports = {
   // S5-Max (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/79#issuecomment-576246934)
-  gen1: [
+  gen1: [ 
     // 0%      = Off
     { homekitTopLevel: 0, miLevel: 200, name: "Off" },
     // 1-35%   = "Light"
@@ -10,6 +10,6 @@ module.exports = {
     // 36-70%  = "Medium"
     { homekitTopLevel: 70, miLevel: 202, name: "Medium" },
     // 71-100% = "High"
-    { homekitTopLevel: 100, miLevel: 203, name: "Hight" },
-  ],
+    { homekitTopLevel: 100, miLevel: 203, name: "Hight" }
+  ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,899 @@
+{
+  "name": "homebridge-roborock",
+  "version": "0.5.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abstract-things": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/abstract-things/-/abstract-things-0.9.0.tgz",
+      "integrity": "sha512-2JJU/nfKfdqan+95KZdrBU/xUfFe/V8O5SE54tFx2e1gsL6dgEd2fcHUaVYJ/tkbRVdIdsIYWk4WyfKxC989rQ==",
+      "requires": {
+        "amounts": "^0.5.0",
+        "appdirectory": "^0.1.0",
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2",
+        "color-temperature": "^0.2.7",
+        "debug": "^3.1.0",
+        "deep-equal": "^1.0.1",
+        "dwaal": "^0.1.4",
+        "foibles": "^0.2.0",
+        "is-mergeable-object": "^1.1.0",
+        "mkdirp": "^0.5.1",
+        "tinkerhub-discovery": "^0.3.1"
+      }
+    },
+    "amounts": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/amounts/-/amounts-0.5.0.tgz",
+      "integrity": "sha512-ffvMjyj6mmn8aPmfdqPeHvt6KO1bTMx0fUi0O7KUtuhitUsxjk23RV8CaLUurX4zwLKfZ009WPfsIvge/XTzJg=="
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "appdirectory": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/appdirectory/-/appdirectory-0.1.0.tgz",
+      "integrity": "sha1-62yBYyDnsqsW9e2ZfyjYIF31Y3U="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "color-temperature": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/color-temperature/-/color-temperature-0.2.7.tgz",
+      "integrity": "sha1-bDKtndnA/gfM8thoBzR4FxIzK0A="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "deasync": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
+      "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^1.7.1"
+      }
+    },
+    "deasync-promise": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deasync-promise/-/deasync-promise-1.0.1.tgz",
+      "integrity": "sha1-KyfeR4Fnr07zS6mYecUuwM7dYcI=",
+      "requires": {
+        "deasync": "^0.1.7"
+      }
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "dwaal": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/dwaal/-/dwaal-0.1.4.tgz",
+      "integrity": "sha512-k/r/3bHW4/uqYC0q+yVFh2ZC2sWHVn+/nmGdVOXpj8sPyBCbK/1xJRrUZZ3mbGy080QKkU+Uv4Nz2936zi7Aaw==",
+      "requires": {
+        "debug": "^3.1.0",
+        "deep-equal": "^1.0.1",
+        "end-of-stream": "^1.4.0",
+        "fs-write-stream-atomic": "^1.0.10",
+        "msgpack-lite": "^0.1.26",
+        "msgpack-sock": "^1.1.0",
+        "unix-socket-leader": "^0.1.2"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "event-lite": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.2.tgz",
+      "integrity": "sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g=="
+    },
+    "eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "foibles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/foibles/-/foibles-0.2.0.tgz",
+      "integrity": "sha512-/5Xm2tfFoDRALzwAZ9mQN0cfOY4aGNmespIn2uS47uPqm9ofuoJZKnj9TJMqMLufaK9vCtLwd3jNweYeKr/7yA=="
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
+    "graceful-fs": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "int64-buffer": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+      "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-mergeable-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.1.tgz",
+      "integrity": "sha512-CPduJfuGg8h8vW74WOxHtHmtQutyQBzR+3MjQ6iDHIYdbOnm1YC7jv43SqCoU8OPGTJD4nibmiryA4kmogbGrA=="
+    },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "miio": {
+      "version": "git://github.com/nicoh88/miio.git#9c3cf59f607005f3eeeb44192055b238bd5ff49b",
+      "from": "git://github.com/nicoh88/miio.git#master",
+      "requires": {
+        "abstract-things": "^0.9.0",
+        "appdirectory": "^0.1.0",
+        "chalk": "^2.3.0",
+        "debug": "^3.1.0",
+        "deep-equal": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "tinkerhub-discovery": "^0.3.1",
+        "yargs": "^10.1.1"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "msgpack-lite": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+      "integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
+      "requires": {
+        "event-lite": "^0.1.1",
+        "ieee754": "^1.1.8",
+        "int64-buffer": "^0.1.9",
+        "isarray": "^1.0.0"
+      }
+    },
+    "msgpack-sock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/msgpack-sock/-/msgpack-sock-1.1.0.tgz",
+      "integrity": "sha1-YCNYe1CqvWirlBnQWAaK3Kf6Hvc=",
+      "requires": {
+        "msgpack-lite": "^0.1.26"
+      }
+    },
+    "node-addon-api": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "requires": {
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    },
+    "pidlockfile": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pidlockfile/-/pidlockfile-1.1.1.tgz",
+      "integrity": "sha1-1nMS+zJt7rReVBmkfBQYd708yYw="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "semver": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+      "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
+      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
+      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "system-sleep": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/system-sleep/-/system-sleep-1.3.6.tgz",
+      "integrity": "sha512-tBQqFUdmuFQhiXtptJR0Nu+fOL0lGFRML2BD0G02bCCCHAZ09Qmu0M/nPzjJL/qx23zQ7arFMo2/LCvfSsgJZA==",
+      "requires": {
+        "deasync-promise": "1.0.1"
+      }
+    },
+    "tinkerhub-discovery": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tinkerhub-discovery/-/tinkerhub-discovery-0.3.1.tgz",
+      "integrity": "sha512-SAf6yys8Klxw7BeXa3sSRuA9q2EVfnwGc1wX1NGTsa7wnCE72T7csyAvUpqc/Tu39ed1wIGvxcejxZF5ZwaZbw==",
+      "requires": {
+        "debug": "^3.1.0",
+        "eventemitter3": "^2.0.3"
+      }
+    },
+    "unix-socket-leader": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unix-socket-leader/-/unix-socket-leader-0.1.2.tgz",
+      "integrity": "sha1-i0zsbT1cbCwwIyFewhDbo4Eilnk=",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "pidlockfile": "^1.1.1"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+      "requires": {
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^8.1.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+      "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+      "requires": {
+        "camelcase": "^4.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.8.4",
+  "name": "homebridge-roborock",
+  "version": "0.5.3",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [
@@ -22,26 +22,13 @@
     "xiaowa c10",
     "mi robot 1s"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum.git"
-  },
-  "bugs": {
-    "url": "https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues"
-  },
-  "homepage": "https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum",
   "engines": {
     "node": ">=10.0.0",
     "homebridge": ">=0.4.45"
   },
   "dependencies": {
-    "miio-nicoh88": ">=0.1.0",
-    "semver": "^7.3.2"
-  },
-  "optionalDependencies": {
+    "miio": "git://github.com/nicoh88/miio.git#master",
+    "semver": "^7.1.2",
     "system-sleep": "^1.3.6"
-  },
-  "devDependencies": {
-    "prettier": "^2.0.5"
   }
 }


### PR DESCRIPTION
# homebridge-roborock
This plugin is a fork of homebridge-xiaomi-roborock-vacuum (thanks to Nico Hartung) with the following changes:
1) Changed the logic to periodically pull status from the device, make the accessories more responsive 
2) Added support for go to target function 
3) The room switches can be used to select multiple rooms before start cleaning. When cleaning fan is powered on, it automatically detects if the device should do a full house clean or room clean based on if any room is enabled for cleaning
4) Fixed the resume function so now it's possible to resume from room cleaning mode
5) More validation logic added together with some other small improvements
6) Fixed no gentle mode for Roborock S5
7) Auto configure the minimal step for fan service so for models with 4 speeds it will be 25% each level and for models with 5 speeds it will be 20% each level. It is no longer possible to choose other percentages.