### PR TITLE
Avoid services requests while the device is not connected yet

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const semver = require("semver");
 const miio = require("./miio");
 const util = require("util");
-const callbackify = require("./lib/callbackify");
+const callbackifyLib = require("./lib/callbackify");
 const safeCall = require("./lib/safeCall");
 let sleep;
 try {
@@ -130,6 +130,10 @@ class XiaomiRoborockVacuum {
   }
 
   initialiseServices() {
+    // Make sure `this.device` exists before calling any of the methods
+    const callbackify = (fn, cb) =>
+      this.device ? callbackifyLib(fn, cb) : cb(new Error("Not connected yet"));
+
     this.services.info = new Service.AccessoryInformation();
     this.services.info
       .setCharacteristic(Characteristic.Manufacturer, "Xiaomi")


### PR DESCRIPTION
We are getting many issues claiming errors when it looks more like connection issues or wrong tokens (i.e. #248)

This PR avoids making Services `get`/`set` calls until `this.device` exists.