### PR TITLE
CLI: read token from the options

### DIFF
--- a/miio/cli/commands/discover.js
+++ b/miio/cli/commands/discover.js
@@ -17,7 +17,7 @@ exports.handler = function (argv) {
   log.info("Discovering devices. Press Ctrl+C to stop.");
   log.plain();
 
-  const browser = deviceFinder();
+  const browser = deviceFinder({ token: argv.token });
   browser.on("available", (device) => {
     try {
       log.device(device);

--- a/miio/cli/commands/inspect.js
+++ b/miio/cli/commands/inspect.js
@@ -41,6 +41,7 @@ exports.handler = function (argv) {
   const browser = deviceFinder({
     instances: true,
     filter: target,
+    token: argv.token,
   });
   browser.on("available", (device) => {
     pending++;

--- a/miio/cli/commands/protocol/call.js
+++ b/miio/cli/commands/protocol/call.js
@@ -15,6 +15,7 @@ exports.handler = function (argv) {
   let pending = 0;
   const browser = deviceFinder({
     filter: target,
+    token: argv.token,
   });
   browser.on("available", (device) => {
     pending++;

--- a/miio/cli/device-finder.js
+++ b/miio/cli/device-finder.js
@@ -44,6 +44,7 @@ module.exports = function (options = {}) {
     connectToDevice({
       address: options.filter,
       withPlaceholder: true,
+      token: options.token,
     })
       .then((device) => result.emit("available", device))
       .catch(() => result.emit("done"));
@@ -53,6 +54,7 @@ module.exports = function (options = {}) {
     const browser = new Devices({
       cacheTime: options.cacheTime || 300,
       filter: options.filter ? asToplevelFilter(filter) : null,
+      token: options.token,
     });
 
     browser.on("available", (device) => {

--- a/miio/lib/discovery.js
+++ b/miio/lib/discovery.js
@@ -130,6 +130,7 @@ class Devices extends BasicDiscovery {
         port: reg.port,
         model: reg.model,
         withPlaceholder: true,
+        token: options.token,
       });
     });
 


### PR DESCRIPTION
This allows running: 
```sh
miio-vacuum discover --token 636e4xxxxxxxxxx
miio-vacuum inspect 192.168.xxx.xxx --token 636e4xxxxxxxxxx
miio-vacuum protocol call 192.168.xxx.xxx miIO.info --token 636e4xxxxxxxxxx
```

And get an enriched response to test out things and make troubleshooting easier.