### PR TITLE
Validate if autoroom and rooms are used at the same time

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,11 @@ class XiaomiRoborockVacuum {
       throw new Error("You must provide a token of the vacuum cleaner.");
     }
 
+    if (this.config.rooms && this.config.autoroom) {
+      throw new Error(`Both "autoroom" and "rooms" config options can't be used at the same time.\n
+      Please, use "autoroom" to retrieve the "rooms" config and remove it when not needed.`);
+    }
+
     // HOMEKIT SERVICES
     this.initialiseServices();
 


### PR DESCRIPTION
Throw an error explaining `autoroom` and `rooms` can't be used at the same time.

We've got tons of issues asking for the room feature not working and it usually turns out they forget to remove `"autoroom"`.