### PR TITLE
[autoroom] Use service's attached .roomId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.2
+
+- [Bug] Refer to the services' attached `.roomId` property (#327)
+
 ## 0.15.1
 
 - [Bug] Fix `autoroom` bug after rooms Services renamed (#324)

--- a/index.js
+++ b/index.js
@@ -1081,13 +1081,22 @@ class XiaomiRoborockVacuum {
     this.services.rooms[roomName].roomId = roomId;
     this.services.rooms[roomName]
       .getCharacteristic(Characteristic.On)
-      .on("get", (cb) => callbackify(() => this.getCleaningRoom(roomId), cb))
-      .on("set", (newState, cb) =>
-        callbackify(() => this.setCleaningRoom(newState, roomId), cb)
+      .on("get", (cb) =>
+        callbackify(
+          () => this.getCleaningRoom(this.services.rooms[roomName].roomId),
+          cb
+        )
       )
-      .on("change", (oldState, newState) => {
-        this.changedPause(newState);
-      });
+      .on("set", (newState, cb) =>
+        callbackify(
+          () =>
+            this.setCleaningRoom(
+              newState,
+              this.services.rooms[roomName].roomId
+            ),
+          cb
+        )
+      );
   }
 
   createZone(zoneName, zoneParams) {


### PR DESCRIPTION
Resolves https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/issues/324#issuecomment-735756653

In the `autoroom` feature, when used as an array, the `roomId` is initially a dummy counter and it's populated later on as the plugin discovers the rooms. For that reason, the callbacks need to refer to the property `.roomId` attached to the service instead of the original `roomId` sent over