### PR TITLE
Ensure SerialNumber is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - **[Breaking change]** Delete the `delay` option. The reasoning: it slows down the start and `homebridge@1.3.0` marks this plugin as slow (#361). Also, it doesn't work as expected in all the OSs.
+- [Bug] Ensure SerialNumber is returned as string (#373)
 
 ## 0.16.2
 

--- a/index.js
+++ b/index.js
@@ -829,7 +829,7 @@ class XiaomiRoborockVacuum {
         `INF getSerialNumber | ${this.model} | Serial Number is ${serialNumber}`
       );
 
-      return serialNumber;
+      return `${serialNumber}`;
     } catch (err) {
       this.log.warn(
         `ERR getSerialNumber | Failed getting the serial number.`,


### PR DESCRIPTION
Fixes #373

For some models, we get `undefined` when obtaining the serial number. Let's ensure it's a string.