### PR TITLE
Fix care percentages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+- [Bug] Percentages could be over 100% when maintenance is long overdue, returning `Filter Life Level` below 0 (#366).
+
 ## 0.17.0
 
 - **[Breaking change]** Delete the `delay` option. The reasoning: it slows down the start and `homebridge@1.3.0` marks this plugin as slow (#361). Also, it doesn't work as expected in all the OSs.

--- a/index.js
+++ b/index.js
@@ -1534,7 +1534,7 @@ class XiaomiRoborockVacuum {
         2
       )}%.`
     );
-    return lifetimepercent;
+    return Math.min(100, lifetimepercent);
   }
 
   async getCareFilter() {
@@ -1549,7 +1549,7 @@ class XiaomiRoborockVacuum {
         "filterWorkTime"
       )} seconds / ${lifetimepercent.toFixed(2)}%.`
     );
-    return lifetimepercent;
+    return Math.min(100, lifetimepercent);
   }
 
   async getCareSideBrush() {
@@ -1564,7 +1564,7 @@ class XiaomiRoborockVacuum {
         "sideBrushWorkTime"
       )} seconds / ${lifetimepercent.toFixed(2)}%.`
     );
-    return lifetimepercent;
+    return Math.min(100, lifetimepercent);
   }
 
   async getCareMainBrush() {
@@ -1579,6 +1579,6 @@ class XiaomiRoborockVacuum {
         "mainBrushWorkTime"
       )} seconds / ${lifetimepercent.toFixed(2)}%.`
     );
-    return lifetimepercent;
+    return Math.min(100, lifetimepercent);
   }
 }


### PR DESCRIPTION
Resolves #366

Fixes an issue when percentages could be over 100% when maintenance is long overdue, so `FilterLifeLevel` could potentially be < 0.