### PR TITLE
Reduce NPM bundle size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,10 @@ mocks.js
 
 # Development configs
 renovate.json
+
+# CI configs
+.github/
+
+# Docs
+images/
+**.md

--- a/.npmignore
+++ b/.npmignore
@@ -15,4 +15,4 @@ renovate.json
 
 # Docs
 images/
-**.md
+miio/docs/


### PR DESCRIPTION
Resolves #376

Dry-Run publish returns
```
npm notice === Tarball Details === 
npm notice name:          homebridge-xiaomi-roborock-vacuum       
npm notice version:       0.17.1                                  
npm notice package size:  43.6 kB                                 
npm notice unpacked size: 179.9 kB                                
npm notice shasum:        cc682e8e73e63da004840d65edbad73da6414a50
npm notice integrity:     sha512-ywIlzhqmUeVJt[...]lZFwUi8dnyO2Q==
npm notice total files:   44                                      
npm notice 
```

That's a reduction of almost 400kB