### PR TITLE
Add new German tutorial link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ To use this plugin, you have to read the "token" of the xiaomi vacuum robots. He
 - :us::gb: - [python-miio - Getting started](https://python-miio.readthedocs.io/en/latest/discovery.html)
 - :de: - [Apple HomeKit Forum - HomeKit.Community](https://forum.smartapfel.de/forum/thread/370-xiaomi-token-auslesen/)
 - :de: - [Homematic-Guru.de](https://homematic-guru.de/xiaomi-vacuum-staubsauger-roboter-mit-homematic-steuern)
+- :de: - [Tutorial with token extractor - simon42.com](https://www.simon42.com/roborock-homekit-token-einfach/)
 
 NOTE: We are not currently aware of how to retrieve the token from the Roborock App. Please, share any findings in the issue #104.
 


### PR DESCRIPTION
Added a link to a new German step-by-step guide on how to get the token via tokenextractor, configure the plugin and mapping the rooms.