### PR TITLE
[Viomi] Skip SerialNumber retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- [Bug] Viomi fails to retrieve the SerialNumber (#456)
+
 ## 0.20.0
 
 - [Enhancement] Roborock S7 Auto-Empty-Dock Support. Thank you @Skjall! (#438)

--- a/miio/lib/devices/viomivacuum.js
+++ b/miio/lib/devices/viomivacuum.js
@@ -138,8 +138,7 @@ module.exports = class extends Vacuum.with(
   }
 
   async getSerialNumber() {
-    const serial = await this.call("get_serial_number");
-    return serial[0].serial_number;
+    return "Unknown"; // We don't know the command to retrieve this bit of info for these models
   }
 
   getRoomMap() {


### PR DESCRIPTION
Viomi models fail to return the serial number. Since it's not a critical piece of information. We'd rather stop requesting it over showing errors in the logs that confuse the users and create a lot of noise.

```
[12/1/2021, 9:42:24 AM] [Xiaomi Mi Robot Vaccum-Mop P] ERR getSerialNumber | Failed getting the serial number. Error: Call to device timed out
    at DeviceInfo._retryOnTimeout (/usr/lib/node_modules/homebridge-xiaomi-roborock-vacuum/miio/lib/device_info.js:295:29)
    at DeviceInfo.call (/usr/lib/node_modules/homebridge-xiaomi-roborock-vacuum/miio/lib/device_info.js:227:12)
    at module.exports.getSerialNumber (/usr/lib/node_modules/homebridge-xiaomi-roborock-vacuum/miio/lib/devices/viomivacuum.js:141:20)
    at XiaomiRoborockVacuum.getSerialNumber (/usr/lib/node_modules/homebridge-xiaomi-roborock-vacuum/index.js:842:28)
    at XiaomiRoborockVacuum.initializeDevice (/usr/lib/node_modules/homebridge-xiaomi-roborock-vacuum/index.js:690:24)
    at XiaomiRoborockVacuum.connect (/usr/lib/node_modules/homebridge-xiaomi-roborock-vacuum/index.js:770:7) {
  code: 'timeout'
}
```