### PR TITLE
feat: add feature toggle for Care Services

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -33,6 +33,12 @@
         "default": false,
         "required": false
       },
+      "disableCareServices": {
+        "title": "Disable Care Services",
+        "type": "boolean",
+        "default": false,
+        "required": false
+      },
       "silent": {
         "title": "Do not log info and debug messages (only log warn and error messages)",
         "type": "boolean",

--- a/index.js
+++ b/index.js
@@ -292,7 +292,9 @@ class XiaomiRoborockVacuum {
     }
 
     // ADDITIONAL HOMEKIT SERVICES
-    this.initialiseCareServices();
+    if (this.config.disableCareServices)
+      this.initialiseCareServices();
+    }
   }
 
   initialiseCareServices() {


### PR DESCRIPTION
Care Services are not supported on older models of Xiamoi Vacuum Robots. This toggle allows users to disable the services