### PR TITLE
Rename `fan` to `mainService`

### DIFF
--- a/src/__snapshots__/xiaomi_roborock_vacuum_accessory.test.ts.snap
+++ b/src/__snapshots__/xiaomi_roborock_vacuum_accessory.test.ts.snap
@@ -15,7 +15,7 @@ exports[`XiaomiRoborockVacuum Client with all config has all the services 1`] = 
 
 exports[`XiaomiRoborockVacuum Client with all config has all the services 2`] = `
 [
-  "fan",
+  "mainService",
   "productInfo",
   "rooms",
   "battery",
@@ -44,7 +44,7 @@ exports[`XiaomiRoborockVacuum Client with minimum config has the basic services 
 
 exports[`XiaomiRoborockVacuum Client with minimum config has the basic services 2`] = `
 [
-  "fan",
+  "mainService",
   "productInfo",
   "rooms",
   "battery",

--- a/src/services/battery_info.ts
+++ b/src/services/battery_info.ts
@@ -1,30 +1,25 @@
-import { HAP, Service } from "homebridge";
-import { Logger } from "../utils/logger";
+import { Service } from "homebridge";
 import { callbackify } from "../utils/callbackify";
-import { PluginService } from "./types";
-import { DeviceManager } from "./device_manager";
-import { Config } from "./config_service";
+import { CoreContext } from "./types";
+import { PluginServiceClass } from "./plugin_service_class";
 
-export class BatteryInfo implements PluginService {
+export class BatteryInfo extends PluginServiceClass {
   private readonly service: Service;
   private isCharging?: boolean;
-  constructor(
-    private readonly hap: HAP,
-    private readonly log: Logger,
-    private readonly config: Config,
-    private readonly deviceManager: DeviceManager
-  ) {
-    this.service = new hap.Service.BatteryService(
+  constructor(coreContext: CoreContext) {
+    super(coreContext);
+
+    this.service = new this.hap.Service.BatteryService(
       `${this.config.name} Battery`
     );
     this.service
-      .getCharacteristic(hap.Characteristic.BatteryLevel)
+      .getCharacteristic(this.hap.Characteristic.BatteryLevel)
       .on("get", (cb) => callbackify(() => this.getBattery(), cb));
     this.service
-      .getCharacteristic(hap.Characteristic.ChargingState)
+      .getCharacteristic(this.hap.Characteristic.ChargingState)
       .on("get", (cb) => callbackify(() => this.getCharging(), cb));
     this.service
-      .getCharacteristic(hap.Characteristic.StatusLowBattery)
+      .getCharacteristic(this.hap.Characteristic.StatusLowBattery)
       .on("get", (cb) => callbackify(() => this.getBatteryLow(), cb));
   }
 

--- a/src/services/care_service.test.ts
+++ b/src/services/care_service.test.ts
@@ -6,7 +6,7 @@ import {
   createDeviceManagerMock,
   DeviceManagerMock,
 } from "./device_manager.mock";
-import { FanService } from "./fan_service";
+import { MainService } from "./main_service";
 import { DeviceManager } from "./device_manager";
 import { HAP } from "homebridge";
 import * as HapJs from "hap-nodejs";
@@ -31,15 +31,17 @@ describe("CareService", () => {
         get services() {
           return fanServices();
         },
-      } as FanService;
+      } as MainService;
 
       const config = applyConfigDefaults({ legacyCareSensors: true });
 
       careService = new CareService(
-        hap,
-        log,
-        config,
-        deviceManagerMock as unknown as DeviceManager,
+        {
+          hap,
+          log,
+          config,
+          deviceManager: deviceManagerMock as unknown as DeviceManager,
+        },
         fan
       );
     });
@@ -90,15 +92,17 @@ describe("CareService", () => {
         get services() {
           return fanServices();
         },
-      } as FanService;
+      } as MainService;
 
       const config = applyConfigDefaults({});
 
       careService = new CareService(
-        hap,
-        log,
-        config,
-        deviceManagerMock as unknown as DeviceManager,
+        {
+          hap,
+          log,
+          config,
+          deviceManager: deviceManagerMock as unknown as DeviceManager,
+        },
         fan
       );
     });

--- a/src/services/care_service.ts
+++ b/src/services/care_service.ts
@@ -1,26 +1,22 @@
 import { HAP, Service } from "homebridge";
-import { PluginService } from "./types";
-import { Logger } from "../utils/logger";
-import { Config } from "./config_service";
-import { DeviceManager } from "./device_manager";
+import { CoreContext } from "./types";
 import { callbackify } from "../utils/callbackify";
 import { Care, Characteristic } from "./custom_care_service";
-import { FanService } from "./fan_service";
+import { MainService } from "./main_service";
+import { PluginServiceClass } from "./plugin_service_class";
 
 export interface CareConfig {
   disableCareServices?: boolean;
   legacyCareSensors?: boolean;
 }
 
-export class CareService implements PluginService {
+export class CareService extends PluginServiceClass {
   public readonly services: Service[];
   constructor(
-    private readonly hap: HAP,
-    private readonly log: Logger,
-    private readonly config: Config,
-    private readonly deviceManager: DeviceManager,
-    private readonly fan: FanService
+    coreContext: CoreContext,
+    private readonly mainService: MainService
   ) {
+    super(coreContext);
     this.services = this.config.legacyCareSensors
       ? this.registerLegacyCustomCareService()
       : this.registerNativeCareServices();
@@ -103,7 +99,7 @@ export class CareService implements PluginService {
   }
 
   private registerNativeCareServices(): Service[] {
-    const mainService = this.fan.services[0]; // Hack for now
+    const mainService = this.mainService.services[0]; // Hack for now
 
     // Register the high-level state of the filters to the main device's Characteristics
     mainService

--- a/src/services/dock_service.ts
+++ b/src/services/dock_service.ts
@@ -1,24 +1,18 @@
-import { HAP, Service } from "homebridge";
-import { PluginService } from "./types";
-import { Logger } from "../utils/logger";
-import { Config } from "./config_service";
-import { DeviceManager } from "./device_manager";
-import { callbackify } from "../utils/callbackify";
-import { RoomsService } from "./rooms_service";
+import { Service } from "homebridge";
 import { distinct, filter } from "rxjs";
+import { CoreContext } from "./types";
+import { callbackify } from "../utils/callbackify";
+import { PluginServiceClass } from "./plugin_service_class";
 
 export interface DockConfig {
   dock: boolean;
 }
 
-export class DockService implements PluginService {
+export class DockService extends PluginServiceClass {
   private readonly service: Service;
-  constructor(
-    private readonly hap: HAP,
-    private readonly log: Logger,
-    private readonly config: Config,
-    private readonly deviceManager: DeviceManager
-  ) {
+  constructor(coreContext: CoreContext) {
+    super(coreContext);
+
     this.service = new this.hap.Service.OccupancySensor(
       `${this.config.name} Dock`
     );

--- a/src/services/dust_collection.ts
+++ b/src/services/dust_collection.ts
@@ -1,22 +1,16 @@
-import { HAP, Service } from "homebridge";
-import { PluginService } from "./types";
-import { Logger } from "../utils/logger";
-import { Config } from "./config_service";
-import { DeviceManager } from "./device_manager";
+import { Service } from "homebridge";
+import { CoreContext } from "./types";
 import { callbackify } from "../utils/callbackify";
+import { PluginServiceClass } from "./plugin_service_class";
 
 export interface DustCollectionConfig {
   dustCollection: boolean;
 }
 
-export class DustCollection implements PluginService {
+export class DustCollection extends PluginServiceClass {
   private readonly service: Service;
-  constructor(
-    private readonly hap: HAP,
-    private readonly log: Logger,
-    private readonly config: Config,
-    private readonly deviceManager: DeviceManager
-  ) {
+  constructor(coreContext: CoreContext) {
+    super(coreContext);
     this.service = new this.hap.Service.Switch(
       `${this.config.name} Dust Collection`,
       "Dust Collection"

--- a/src/services/find_me_service.ts
+++ b/src/services/find_me_service.ts
@@ -1,26 +1,18 @@
-import { HAP, Service } from "homebridge";
-import { PluginService } from "./types";
-import { Logger } from "../utils/logger";
-import { Config } from "./config_service";
-import { DeviceManager } from "./device_manager";
-import { callbackify } from "../utils/callbackify";
-import { RoomsService } from "./rooms_service";
-import { distinct, filter } from "rxjs";
+import { Service } from "homebridge";
 import { CharacteristicValue } from "hap-nodejs/dist/types";
+import { CoreContext } from "./types";
+import { callbackify } from "../utils/callbackify";
+import { PluginServiceClass } from "./plugin_service_class";
 
 export interface FindMeConfig {
   findMe: boolean;
   findMeWord: string;
 }
 
-export class FindMeService implements PluginService {
+export class FindMeService extends PluginServiceClass {
   private readonly service?: Service;
-  constructor(
-    private readonly hap: HAP,
-    private readonly log: Logger,
-    private readonly config: Config,
-    private readonly deviceManager: DeviceManager
-  ) {
+  constructor(coreContext: CoreContext) {
+    super(coreContext);
     if (this.config.findMe) {
       this.service = new this.hap.Service.Switch(
         `${this.config.name} ${this.config.findMeWord}`,

--- a/src/services/go_to_service.ts
+++ b/src/services/go_to_service.ts
@@ -1,11 +1,7 @@
-import { HAP, Service } from "homebridge";
-import { PluginService } from "./types";
-import { Logger } from "../utils/logger";
-import { Config } from "./config_service";
-import { DeviceManager } from "./device_manager";
+import { Service } from "homebridge";
+import { CoreContext } from "./types";
 import { callbackify } from "../utils/callbackify";
-import { RoomsService } from "./rooms_service";
-import { distinct, filter } from "rxjs";
+import { PluginServiceClass } from "./plugin_service_class";
 
 export interface GoToConfig {
   goTo: boolean;
@@ -14,14 +10,10 @@ export interface GoToConfig {
   goToY: number;
 }
 
-export class GoToService implements PluginService {
+export class GoToService extends PluginServiceClass {
   private readonly service: Service;
-  constructor(
-    private readonly hap: HAP,
-    private readonly log: Logger,
-    private readonly config: Config,
-    private readonly deviceManager: DeviceManager
-  ) {
+  constructor(coreContext: CoreContext) {
+    super(coreContext);
     this.service = new this.hap.Service.Switch(
       `${this.config.name} ${this.config.goToWord}`,
       "GoTo Switch"

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -7,7 +7,7 @@ export { DustCollection } from "./dust_collection";
 export { PauseSwitch } from "./pause_switch";
 export { FindMeService } from "./find_me_service";
 export { GoToService } from "./go_to_service";
-export { FanService } from "./fan_service";
+export { MainService } from "./main_service";
 export { ProductInfo } from "./product_info";
 export { RoomsService } from "./rooms_service";
 export { WaterBoxService } from "./water_box_service";

--- a/src/services/pause_switch.ts
+++ b/src/services/pause_switch.ts
@@ -1,26 +1,22 @@
-import { HAP, Service } from "homebridge";
-import { PluginService } from "./types";
-import { Logger } from "../utils/logger";
-import { Config } from "./config_service";
-import { DeviceManager } from "./device_manager";
+import { Service } from "homebridge";
+import { distinct, filter } from "rxjs";
+import { CoreContext } from "./types";
 import { callbackify } from "../utils/callbackify";
 import { RoomsService } from "./rooms_service";
-import { distinct, filter } from "rxjs";
+import { PluginServiceClass } from "./plugin_service_class";
 
 export interface PauseConfig {
   pause: boolean;
   pauseWord: string;
 }
 
-export class PauseSwitch implements PluginService {
+export class PauseSwitch extends PluginServiceClass {
   private readonly service: Service;
   constructor(
-    private readonly hap: HAP,
-    private readonly log: Logger,
-    private readonly config: Config,
-    private readonly deviceManager: DeviceManager,
+    coreContext: CoreContext,
     private readonly roomsService: RoomsService
   ) {
+    super(coreContext);
     this.service = new this.hap.Service.Switch(
       `${this.config.name} ${this.config.pauseWord}`,
       "Pause Switch"

--- a/src/services/plugin_service_class.ts
+++ b/src/services/plugin_service_class.ts
@@ -1,0 +1,23 @@
+import { CoreContext, PluginService } from "./types";
+import { HAP } from "homebridge";
+import { Logger } from "../utils/logger";
+import { Config } from "./config_service";
+import { DeviceManager } from "./device_manager";
+
+export abstract class PluginServiceClass implements PluginService {
+  protected readonly hap: HAP;
+  protected readonly log: Logger;
+  protected readonly config: Config;
+  protected readonly deviceManager: DeviceManager;
+
+  protected constructor({ hap, log, config, deviceManager }: CoreContext) {
+    this.hap = hap;
+    this.log = log;
+    this.config = config;
+    this.deviceManager = deviceManager;
+  }
+
+  public abstract init(): Promise<void>;
+
+  public abstract get services();
+}

--- a/src/services/product_info.ts
+++ b/src/services/product_info.ts
@@ -1,30 +1,26 @@
-import { HAP, Service } from "homebridge";
-import { Logger } from "../utils/logger";
+import { Service } from "homebridge";
 import { callbackify } from "../utils/callbackify";
-import { PluginService } from "./types";
-import { DeviceManager } from "./device_manager";
+import { CoreContext } from "./types";
 import { concatMap, filter } from "rxjs";
+import { PluginServiceClass } from "./plugin_service_class";
 
-export class ProductInfo implements PluginService {
+export class ProductInfo extends PluginServiceClass {
   public firmware?: string;
   private readonly service: Service;
-  constructor(
-    private readonly hap: HAP,
-    private readonly log: Logger,
-    private readonly deviceManager: DeviceManager
-  ) {
-    this.service = new hap.Service.AccessoryInformation();
+  constructor(coreContext: CoreContext) {
+    super(coreContext);
+    this.service = new this.hap.Service.AccessoryInformation();
     this.service
-      .setCharacteristic(hap.Characteristic.Manufacturer, "Xiaomi")
-      .setCharacteristic(hap.Characteristic.Model, "Roborock");
+      .setCharacteristic(this.hap.Characteristic.Manufacturer, "Xiaomi")
+      .setCharacteristic(this.hap.Characteristic.Model, "Roborock");
     this.service
-      .getCharacteristic(hap.Characteristic.FirmwareRevision)
+      .getCharacteristic(this.hap.Characteristic.FirmwareRevision)
       .on("get", (cb) => callbackify(() => this.getFirmware(), cb));
     this.service
-      .getCharacteristic(hap.Characteristic.Model)
+      .getCharacteristic(this.hap.Characteristic.Model)
       .on("get", (cb) => callbackify(() => this.deviceManager.model, cb));
     this.service
-      .getCharacteristic(hap.Characteristic.SerialNumber)
+      .getCharacteristic(this.hap.Characteristic.SerialNumber)
       .on("get", (cb) => callbackify(() => this.getSerialNumber(), cb));
   }
 

--- a/src/services/rooms_service.ts
+++ b/src/services/rooms_service.ts
@@ -1,9 +1,8 @@
-import { HAP, Service } from "homebridge";
+import { Service } from "homebridge";
 import { callbackify } from "../utils/callbackify";
-import { Logger } from "../utils/logger";
-import type { DeviceManager } from "./device_manager";
-import { PluginService } from "./types";
+import { CoreContext } from "./types";
 import { cleaningStatuses } from "../utils/constants";
+import { PluginServiceClass } from "./plugin_service_class";
 
 export interface RoomsConfig {
   cleanword: string;
@@ -16,18 +15,16 @@ interface Room extends Service {
   roomId: string;
 }
 
-export class RoomsService implements PluginService {
+export class RoomsService extends PluginServiceClass {
   public readonly roomIdsToClean = new Set<string>();
   private readonly rooms: Record<string, Room> = {};
   private roomTimeout = setTimeout(() => {}, 0);
 
   constructor(
-    private readonly hap: HAP,
-    private readonly log: Logger,
-    private readonly config: RoomsConfig,
-    private readonly deviceManager: DeviceManager,
+    coreContext: CoreContext,
     private readonly setCleaning: (clean: boolean) => Promise<void>
   ) {
+    super(coreContext);
     if (this.config.rooms && this.config.autoroom) {
       throw new Error(`Both "autoroom" and "rooms" config options can't be used at the same time.\n
       Please, use "autoroom" to retrieve the "rooms" config and remove it when not needed.`);

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,6 +1,16 @@
-import { Service } from "homebridge";
+import { HAP, Service } from "homebridge";
+import { Logger } from "../utils/logger";
+import { Config } from "./config_service";
+import { DeviceManager } from "./device_manager";
 
 export interface PluginService {
   init(): Promise<void>;
   get services(): Service[];
+}
+
+export interface CoreContext {
+  hap: HAP;
+  log: Logger;
+  config: Config;
+  deviceManager: DeviceManager;
 }


### PR DESCRIPTION
Part of #458.

In order to change the `Fan` to be a `Switch`, we need to rename the service to `main` so the name is unlinked to the actual HB service type