### PR TITLE
Set `hap-nodejs` as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "chalk": "4.1.2",
         "debug": "4.3.4",
         "deep-equal": "2.0.5",
-        "hap-nodejs": "^0.10.2",
         "rxjs": "^7.5.6",
         "semver": "7.3.7",
         "tinkerhub-discovery": "0.3.1",
@@ -39,6 +38,9 @@
       "engines": {
         "homebridge": ">=0.4.45",
         "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "hap-nodejs": "^0.10.2"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "chalk": "4.1.2",
     "debug": "4.3.4",
     "deep-equal": "2.0.5",
-    "hap-nodejs": "^0.10.2",
     "rxjs": "^7.5.6",
     "semver": "7.3.7",
     "tinkerhub-discovery": "0.3.1",
@@ -71,5 +70,8 @@
     "prettier": "2.7.1",
     "rimraf": "3.0.2",
     "typescript": "4.8.2"
+  },
+  "peerDependencies": {
+    "hap-nodejs": "^0.10.2"
   }
 }


### PR DESCRIPTION
Resolves #533

Moving `hap-nodejs` to a peer dependency declares the need of them in homebrige but it doesn't bring an additional version with it :)