### PR TITLE
CI: Split build steps

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,8 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Node.js CI
-
 on:
   push:
     branches: [master]
@@ -10,27 +5,13 @@ on:
     branches: [master, next]
 
 jobs:
-  build:
-    name: "Typescript build"
+  lint:
+    name: "Check lint rules"
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-      - run: npm ci
-      - run: npm run build
-
-  lint:
-    name: "Check lint rules"
-    runs-on: ubuntu-latest
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -41,6 +22,24 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run lint
+
+  build:
+    name: "Typescript build"
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
 
   tests:
     name: "Run tests"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    name: "Typescript build"
     runs-on: ubuntu-latest
 
     strategy:
@@ -23,9 +24,40 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
+
+  lint:
+    name: "Check lint rules"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
       - run: npm ci
       - run: npm run lint
-      - run: npm run build --if-present
+
+  tests:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci
       - run: npm test -- --coverage
         env:
           CI: true


### PR DESCRIPTION
Ideally, each step should be shown separately in the checks to make it more obvious which one failed.