### PR TITLE
Add CI name

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,3 +1,5 @@
+name: "CI"
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Showing the path of the `.github/workflows/nodejs.yml` instead of "CI" in the list of checks is ugly 😇 