### PR TITLE
Enforce (or try to) the right order of the services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - [Bug] Remove peer dependency on `hap-nodejs` as some folks had issues (#558)
+- [Bug] Accessories are randomly presented so the main service loses the primary status (#542)
 
 ## 0.26.5
 


### PR DESCRIPTION
Tries to resolve #542 by applying these changes:

* It returns the main fan/switch service first in the list of services.
* On top of that, it explicitly sets all other services as non-primary and linked to the main fan/switch service.

cc @luc-ass do you think this might work?