### PR TITLE
Reset switches after cleaning is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Bug] Remove peer dependency on `hap-nodejs` as some folks had issues (#558)
 - [Bug] Accessories are randomly presented so the main service loses the primary status (#542)
+- [Bug] Reset cleaning status of Rooms and Zones after cleaning is completed (#546)
 
 ## 0.26.5
 

--- a/src/services/zones_service.ts
+++ b/src/services/zones_service.ts
@@ -1,4 +1,5 @@
 import { Service } from "homebridge";
+import { filter } from "rxjs";
 import { CoreContext } from "./types";
 import { MainService } from "./main_service";
 import { PluginServiceClass } from "./plugin_service_class";
@@ -32,7 +33,20 @@ export class ZonesService extends PluginServiceClass {
     }
   }
 
-  public async init() {}
+  public async init() {
+    this.deviceManager.stateChanged$
+      .pipe(filter(({ key }) => key === "cleaning"))
+      .subscribe(({ value }) => {
+        const isCleaning = value === true;
+        if (!isCleaning) {
+          this.services.forEach((zone) => {
+            zone
+              .getCharacteristic(this.hap.Characteristic.On)
+              .updateValue(false);
+          });
+        }
+      });
+  }
 
   public get services(): Service[] {
     return [...Object.values(this.zones)];


### PR DESCRIPTION
Resolves #546.
Resolves #559

* All the services subscribe to the stateChanged$ observable and apply the changes.
* The `distinct` clause is only used for logging purposes, but services always update the service (just in case).