### PR TITLE
[Room Service] Wait for connection before applying the auto-room discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- [Bug] Room Service: Wait for connection before applying the auto-room discovery (#618)
+
 ## 0.28.0
 
 - [New Model] Improved support to Viomi models based on the implementation from `python-miio` (#580)

--- a/src/services/device_manager.ts
+++ b/src/services/device_manager.ts
@@ -1,5 +1,12 @@
 import { HAP } from "homebridge";
-import { BehaviorSubject, distinct, exhaustMap, Subject, timer } from "rxjs";
+import {
+  BehaviorSubject,
+  distinct,
+  exhaustMap,
+  filter,
+  Subject,
+  timer,
+} from "rxjs";
 import miio from "../miio";
 import { Logger } from "../utils/logger";
 import { MiioDevice } from "../utils/miio_types";
@@ -34,7 +41,7 @@ export class DeviceManager {
   private readonly internalStateChanged$ = new Subject<StateChangedEvent>();
   public readonly errorChanged$ = this.internalErrorChanged$.pipe(distinct());
   public readonly stateChanged$ = this.internalStateChanged$.asObservable();
-  public readonly deviceConnected$ = this.internalDevice$.asObservable();
+  public readonly deviceConnected$ = this.internalDevice$.pipe(filter(Boolean));
 
   private connectingPromise: Promise<void> | null = null;
   private connectRetry = setTimeout(() => void 0, 100); // Noop timeout only to initialise the property

--- a/src/services/rooms_service.test.ts
+++ b/src/services/rooms_service.test.ts
@@ -1,0 +1,66 @@
+import { HAP } from "homebridge";
+import * as HapJs from "hap-nodejs";
+import { Subject } from "rxjs";
+import { RoomsService } from "./rooms_service";
+import {
+  createDeviceManagerMock,
+  DeviceManagerMock,
+} from "./device_manager.mock";
+import { getLoggerMock } from "../utils/logger.mock";
+import { applyConfigDefaults, Config } from "./config_service";
+import { MiioDevice } from "../utils/miio_types";
+import { miio } from "../test.mocks";
+
+describe("RoomsService", () => {
+  let roomsService: RoomsService;
+  let deviceManagerMock: DeviceManagerMock;
+  let hap: HAP;
+  const setCleaning = jest.fn();
+
+  async function createRoomService(partialConfig: Partial<Config>) {
+    hap = HapJs;
+    const log = getLoggerMock();
+    deviceManagerMock = createDeviceManagerMock();
+    const config = applyConfigDefaults(partialConfig);
+
+    roomsService = new RoomsService(
+      {
+        hap,
+        log,
+        config,
+        deviceManager: deviceManagerMock,
+      },
+      setCleaning
+    );
+
+    await roomsService.init();
+  }
+
+  afterEach(() => {
+    (deviceManagerMock.stateChanged$ as Subject<unknown>).complete();
+    jest.resetAllMocks();
+  });
+
+  describe("with the default config", () => {
+    beforeEach(async () => {
+      await createRoomService({});
+    });
+
+    test("default config returns zero services", () => {
+      expect(roomsService.services).toStrictEqual([]);
+    });
+  });
+
+  test("throws an error if rooms and autoroom are present at the same time", async () => {
+    await expect(
+      createRoomService({ rooms: [], autoroom: true })
+    ).rejects.toThrowError();
+  });
+
+  test("creates a declared room", async () => {
+    await createRoomService({ rooms: [{ id: 16, name: "Kitchen" }] });
+    expect(roomsService.services).toHaveLength(1);
+  });
+
+  // TODO: Keep adding tests
+});

--- a/src/services/rooms_service.ts
+++ b/src/services/rooms_service.ts
@@ -50,8 +50,8 @@ export class RoomsService extends PluginServiceClass {
       .subscribe(({ value }) => {
         const isCleaning = value === true;
         if (!isCleaning) {
-          this.services.forEach((zone) => {
-            zone
+          this.services.forEach((room) => {
+            room
               .getCharacteristic(this.hap.Characteristic.On)
               .updateValue(false);
           });
@@ -59,10 +59,10 @@ export class RoomsService extends PluginServiceClass {
         }
       });
 
-    // Await for the device to be connected
-    await firstValueFrom(this.deviceManager.deviceConnected$);
-
     if (this.config.autoroom) {
+      // Await for the device to be connected
+      await firstValueFrom(this.deviceManager.deviceConnected$);
+
       if (Array.isArray(this.config.autoroom)) {
         await this.getRoomList();
       } else {

--- a/src/services/rooms_service.ts
+++ b/src/services/rooms_service.ts
@@ -1,5 +1,5 @@
 import { Service } from "homebridge";
-import { filter } from "rxjs";
+import { filter, firstValueFrom } from "rxjs";
 import { CoreContext } from "./types";
 import { PluginServiceClass } from "./plugin_service_class";
 
@@ -58,6 +58,9 @@ export class RoomsService extends PluginServiceClass {
           this.roomIdsToClean.clear();
         }
       });
+
+    // Await for the device to be connected
+    await firstValueFrom(this.deviceManager.deviceConnected$);
 
     if (this.config.autoroom) {
       if (Array.isArray(this.config.autoroom)) {


### PR DESCRIPTION
Resolves #609

If the connection was not established before the autoroom discovery logic took place, the plugin crashes.

This PR holds that logic from running until the connection is successfully made.