### PR TITLE
Fix iOS16 naming issues but preserving user overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bugs/
 .bin/
 coverage/
 dist/
+persist/

--- a/.npmignore
+++ b/.npmignore
@@ -10,6 +10,7 @@ coverage/
 __snapshots__/
 **.test.js
 src/test.mocks.ts
+persist/
 
 # Development configs
 renovate.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,21 @@
 {
   "prettier.trailingComma": "es5",
   "editor.formatOnSave": false,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": null,
   "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
   "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
   "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
   "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+## 0.31.1
+
+- [Bug] Fix iOS16 naming issues but preserving user overrides ([#845](https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/pull/845))
+
 ## 0.31.0
 
 - [Bug] Fixed: push room names from settings to homekit ([#829](https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/pull/829)) (thank you, @YoeriVD)

--- a/src/services/dock_service.ts
+++ b/src/services/dock_service.ts
@@ -2,6 +2,7 @@ import { Service } from "homebridge";
 import { distinct, filter, map, tap } from "rxjs";
 import { CoreContext } from "./types";
 import { PluginServiceClass } from "./plugin_service_class";
+import { ensureName } from "../utils/ensure_name";
 
 export interface DockConfig {
   dock: boolean;
@@ -12,9 +13,9 @@ export class DockService extends PluginServiceClass {
   constructor(coreContext: CoreContext) {
     super(coreContext);
 
-    this.service = new this.hap.Service.OccupancySensor(
-      `${this.config.name} Dock`
-    );
+    const name = `${this.config.name} Dock`;
+    this.service = new this.hap.Service.OccupancySensor(name);
+    ensureName(this.hap, this.service, name);
     this.service
       .getCharacteristic(this.hap.Characteristic.OccupancyDetected)
       .onGet(() => this.getDocked());

--- a/src/services/dust_collection.ts
+++ b/src/services/dust_collection.ts
@@ -1,6 +1,7 @@
 import { Service } from "homebridge";
 import { CoreContext } from "./types";
 import { PluginServiceClass } from "./plugin_service_class";
+import { ensureName } from "../utils/ensure_name";
 
 export interface DustCollectionConfig {
   dustCollection: boolean;
@@ -10,10 +11,9 @@ export class DustCollection extends PluginServiceClass {
   private readonly service: Service;
   constructor(coreContext: CoreContext) {
     super(coreContext);
-    this.service = new this.hap.Service.Switch(
-      `${this.config.name} Dust Collection`,
-      "Dust Collection"
-    );
+    const name = `${this.config.name} Dust Collection`;
+    this.service = new this.hap.Service.Switch(name, "Dust Collection");
+    ensureName(this.hap, this.service, name);
     this.service
       .getCharacteristic(this.hap.Characteristic.On)
       .onGet(() => this.getDustCollectionState())

--- a/src/services/find_me_service.ts
+++ b/src/services/find_me_service.ts
@@ -2,6 +2,7 @@ import { Service } from "homebridge";
 import { CharacteristicValue } from "hap-nodejs/dist/types";
 import { CoreContext } from "./types";
 import { PluginServiceClass } from "./plugin_service_class";
+import { ensureName } from "../utils/ensure_name";
 
 export interface FindMeConfig {
   findMe: boolean;
@@ -13,10 +14,9 @@ export class FindMeService extends PluginServiceClass {
   constructor(coreContext: CoreContext) {
     super(coreContext);
     if (this.config.findMe) {
-      this.service = new this.hap.Service.Switch(
-        `${this.config.name} ${this.config.findMeWord}`,
-        "FindMe Switch"
-      );
+      const name = `${this.config.name} ${this.config.findMeWord}`;
+      this.service = new this.hap.Service.Switch(name, "FindMe Switch");
+      ensureName(this.hap, this.service, name);
       this.service
         .getCharacteristic(this.hap.Characteristic.On)
         .onGet(() => false)

--- a/src/services/go_to_service.ts
+++ b/src/services/go_to_service.ts
@@ -1,6 +1,7 @@
 import { Service } from "homebridge";
 import { CoreContext } from "./types";
 import { PluginServiceClass } from "./plugin_service_class";
+import { ensureName } from "../utils/ensure_name";
 
 export interface GoToConfig {
   goTo: boolean;
@@ -13,10 +14,9 @@ export class GoToService extends PluginServiceClass {
   private readonly service: Service;
   constructor(coreContext: CoreContext) {
     super(coreContext);
-    this.service = new this.hap.Service.Switch(
-      `${this.config.name} ${this.config.goToWord}`,
-      "GoTo Switch"
-    );
+    const name = `${this.config.name} ${this.config.goToWord}`;
+    this.service = new this.hap.Service.Switch(name, "GoTo Switch");
+    ensureName(this.hap, this.service, name);
     this.service
       .getCharacteristic(this.hap.Characteristic.On)
       .onGet(() => this.getGoToState())

--- a/src/services/pause_switch.ts
+++ b/src/services/pause_switch.ts
@@ -3,6 +3,7 @@ import { distinct, filter } from "rxjs";
 import { CoreContext } from "./types";
 import { RoomsService } from "./rooms_service";
 import { PluginServiceClass } from "./plugin_service_class";
+import { ensureName } from "../utils/ensure_name";
 
 export interface PauseConfig {
   pause: boolean;
@@ -16,10 +17,9 @@ export class PauseSwitch extends PluginServiceClass {
     private readonly roomsService: RoomsService
   ) {
     super(coreContext);
-    this.service = new this.hap.Service.Switch(
-      `${this.config.name} ${this.config.pauseWord}`,
-      "Pause Switch"
-    );
+    const name = `${this.config.name} ${this.config.pauseWord}`;
+    this.service = new this.hap.Service.Switch(name, "Pause Switch");
+    ensureName(this.hap, this.service, name);
     this.service
       .getCharacteristic(this.hap.Characteristic.On)
       .onGet(() => this.getPauseState())

--- a/src/services/rooms_service.ts
+++ b/src/services/rooms_service.ts
@@ -2,6 +2,7 @@ import { Service } from "homebridge";
 import { filter, firstValueFrom } from "rxjs";
 import { CoreContext } from "./types";
 import { PluginServiceClass } from "./plugin_service_class";
+import { ensureName } from "../utils/ensure_name";
 
 export interface RoomsConfig {
   cleanword: string;
@@ -84,12 +85,7 @@ export class RoomsService extends PluginServiceClass {
       { roomId }
     );
 
-    room.addOptionalCharacteristic(this.hap.Characteristic.ConfiguredName);
-    room.setCharacteristic(this.hap.Characteristic.ConfiguredName, switchName);
-    room.updateCharacteristic(
-      this.hap.Characteristic.ConfiguredName,
-      switchName
-    );
+    ensureName(this.hap, room, switchName);
 
     room
       .getCharacteristic(this.hap.Characteristic.On)

--- a/src/services/water_box_service.test.ts
+++ b/src/services/water_box_service.test.ts
@@ -52,9 +52,9 @@ describe("WaterBoxService", () => {
     expect(waterboxService.services).toHaveLength(1);
   });
 
-  test("registers 3 characteristics", () => {
+  test("registers 4 characteristics", () => {
     const service = waterboxService.services[0];
-    expect(service.characteristics).toHaveLength(3);
+    expect(service.characteristics).toHaveLength(4);
   });
 
   describe("Characteristic getters", () => {

--- a/src/services/water_box_service.ts
+++ b/src/services/water_box_service.ts
@@ -5,6 +5,7 @@ import { findSpeedModes } from "../utils/find_speed_modes";
 import { ProductInfo } from "./product_info";
 import { MainService } from "./main_service";
 import { PluginServiceClass } from "./plugin_service_class";
+import { ensureName } from "../utils/ensure_name";
 
 export interface WaterBoxConfig {
   waterBox: boolean;
@@ -18,10 +19,9 @@ export class WaterBoxService extends PluginServiceClass {
     private readonly mainService: MainService
   ) {
     super(coreContext);
-    this.service = new this.hap.Service.Fan(
-      `${this.config.name} Water Box`,
-      "Water Box"
-    );
+    const name = `${this.config.name} Water Box`;
+    this.service = new this.hap.Service.Fan(name, "Water Box");
+    ensureName(this.hap, this.service, name);
     this.service
       .getCharacteristic(this.hap.Characteristic.RotationSpeed)
       .onGet(() => this.getWaterSpeed())

--- a/src/services/zones_service.ts
+++ b/src/services/zones_service.ts
@@ -3,6 +3,7 @@ import { filter } from "rxjs";
 import { CoreContext } from "./types";
 import { MainService } from "./main_service";
 import { PluginServiceClass } from "./plugin_service_class";
+import { ensureName } from "../utils/ensure_name";
 
 interface ZoneDefinition {
   name: string;
@@ -54,10 +55,12 @@ export class ZonesService extends PluginServiceClass {
 
   private createZone(zoneName: string, zoneParams: ZoneDefinition["zone"]) {
     this.log.info(`createRoom | Zone ${zoneName} (${zoneParams})`);
+    const name = `${this.config.cleanword} ${zoneName}`;
     this.zones[zoneName] = new this.hap.Service.Switch(
-      `${this.config.cleanword} ${zoneName}`,
+      name,
       "zoneCleaning" + zoneName
     );
+    ensureName(this.hap, this.zones[zoneName], name);
     this.zones[zoneName]
       .getCharacteristic(this.hap.Characteristic.On)
       .onGet(() => this.mainService.getCleaning())

--- a/src/test.mocks.ts
+++ b/src/test.mocks.ts
@@ -1,7 +1,7 @@
 // ============= MIIO MOCKS ================
 
 import { API } from "homebridge";
-import { Characteristic } from "hap-nodejs";
+import { Characteristic, HAPStorage } from "hap-nodejs";
 import { Socket } from "net";
 import { MiioDevice } from "./utils/miio_types";
 
@@ -86,5 +86,5 @@ const Service = Object.assign(createServiceMock(), {
 export const createHomebridgeMock = () =>
   ({
     registerAccessory: jest.fn(),
-    hap: { Characteristic, Service },
+    hap: { Characteristic, Service, HAPStorage },
   }) as unknown as jest.Mocked<API>;

--- a/src/utils/ensure_name.test.ts
+++ b/src/utils/ensure_name.test.ts
@@ -1,0 +1,52 @@
+import * as hap from "hap-nodejs";
+import { ensureName } from "./ensure_name";
+
+describe("ensureName", () => {
+  const getItemSpy = jest.spyOn(hap.HAPStorage.storage(), "getItemSync");
+  const setItemSpy = jest.spyOn(hap.HAPStorage.storage(), "setItemSync");
+
+  const service = new hap.Service.Switch("test", "test");
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    service
+      .getCharacteristic(hap.Characteristic.ConfiguredName)
+      .removeAllListeners("change");
+  });
+
+  test("sets the default name", () => {
+    const setCharacteristicSpy = jest.spyOn(service, "setCharacteristic");
+    ensureName(hap, service, "custom test");
+    expect(setCharacteristicSpy).toHaveBeenCalledTimes(1);
+    expect(setCharacteristicSpy).toHaveBeenCalledWith(
+      hap.Characteristic.ConfiguredName,
+      "custom test"
+    );
+    expect(setItemSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test("does not set the default name", () => {
+    getItemSpy.mockReturnValueOnce("hi there!");
+    const setCharacteristicSpy = jest.spyOn(service, "setCharacteristic");
+    ensureName(hap, service, "custom test");
+    expect(setCharacteristicSpy).toHaveBeenCalledTimes(0);
+    expect(setItemSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test("stores a custom name in cache", () => {
+    getItemSpy.mockReturnValueOnce("hi there!");
+    ensureName(hap, service, "custom test");
+    service.updateCharacteristic(
+      hap.Characteristic.ConfiguredName,
+      "changed name"
+    );
+    expect(setItemSpy).toHaveBeenCalledTimes(1);
+    expect(setItemSpy).toHaveBeenCalledWith(
+      "homebridge-xiaomi-roborock-vacuum-configured-name-custom_test",
+      "changed name"
+    );
+  });
+});

--- a/src/utils/ensure_name.ts
+++ b/src/utils/ensure_name.ts
@@ -1,0 +1,18 @@
+import { Service, HAP } from "homebridge";
+
+export function ensureName(hap: HAP, service: Service, name: string) {
+  const key = [
+    `homebridge-xiaomi-roborock-vacuum`,
+    `configured-name`,
+    name.replaceAll(" ", "_"),
+  ].join("-");
+  service.addOptionalCharacteristic(hap.Characteristic.ConfiguredName);
+  if (!hap.HAPStorage.storage().getItemSync(key)) {
+    service.setCharacteristic(hap.Characteristic.ConfiguredName, name);
+  }
+  service
+    .getCharacteristic(hap.Characteristic.ConfiguredName)
+    .on("change", ({ newValue }) => {
+      hap.HAPStorage.storage().setItemSync(key, newValue);
+    });
+}


### PR DESCRIPTION
Follow up to https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/pull/829, but extending that logic to all the services/accessories.

Additionally, it resolves https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/issues/841: when the user applies a name override, it'll persist it, so that it knows it shouldn't reapply the names.