### PR TITLE
Add support for Roborock Q5 Pro

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "roborock s6",
     "roborock t6",
     "roborock t4",
+    "roborock q5 pro",
     "xiaowa lite c10",
     "xiaowa c10",
     "mi robot 1s"

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -113,6 +113,12 @@ export const MODELS: Record<string, ModelDefinition[]> = {
       waterspeed: watermodes["gen1+custom"],
     },
   ],
+  // Q5 Pro
+  "roborock.vacuum.a72": [
+    {
+      speed: speedmodes["gen4+custom"],
+    },
+  ],
   // Q8S Max+
   "roborock.vacuum.a73": [
     {


### PR DESCRIPTION
Hey there 👋 Per suggestion in the last paragraph of README, I've added a mapping for Roborock Q5 Pro (`roborock.vacuum.a72`) and tested it locally. Seems to work! Do I need to do anything else to get this merged, or would this be enough?

P.S. This should also close: https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/issues/1017 
P.P.S. Thank you for creating the plugin 🙏 