### PR TITLE
Fix periodic device state polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- [Bug] Restore periodic vacuum state polling and connection recovery.
+
 ## 0.35.0
 
 - [New Model] Add support for Roborock Q5 Pro. Thank you @kirylvolkau ([#1178](https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/pull/1178))

--- a/src/services/device_manager.test.ts
+++ b/src/services/device_manager.test.ts
@@ -6,6 +6,14 @@ import { DeviceManager } from "./device_manager";
 describe("DeviceManager", () => {
   const log = getLoggerMock();
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    miio.device.matches.mockReturnValue(false);
+    miio.device.property.mockReturnValue(undefined);
+    miio.device.poll.mockResolvedValue(undefined);
+    miio.device.state.mockResolvedValue({});
+  });
+
   describe("constructor", () => {
     test("Fails if no IP provided", () => {
       expect(
@@ -34,6 +42,10 @@ describe("DeviceManager", () => {
   });
 
   describe("get device", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     test("fails when not connected yet", () => {
       const deviceManager = new DeviceManager(createHomebridgeMock().hap, log, {
         ip: "192.168.0.1",
@@ -46,18 +58,96 @@ describe("DeviceManager", () => {
     });
 
     test("connects and loads", async () => {
+      jest.useFakeTimers();
       miio.device.matches.mockReturnValue(true);
       miio.device.property.mockReturnValue("cleaning");
       const deviceManager = new DeviceManager(createHomebridgeMock().hap, log, {
         ip: "192.168.0.1",
         token: "token",
       });
-      await new Promise((resolve) => process.nextTick(resolve));
+      await jest.advanceTimersByTimeAsync(0);
       expect(deviceManager.model).toStrictEqual("test-model");
       expect(deviceManager.device).toStrictEqual(miio.device);
       expect(deviceManager.state).toStrictEqual("cleaning");
       expect(deviceManager.isCleaning).toStrictEqual(true);
       expect(deviceManager.isPaused).toStrictEqual(false);
+    });
+  });
+
+  describe("state polling", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      miio.device.matches.mockReturnValue(true);
+      miio.device.property.mockReturnValue("charging");
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const createConnectedDeviceManager = async () => {
+      const deviceManager = new DeviceManager(createHomebridgeMock().hap, log, {
+        ip: "192.168.0.1",
+        token: "token",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      return deviceManager;
+    };
+
+    test("refreshes the device state every 30 seconds", async () => {
+      await createConnectedDeviceManager();
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(miio.device.poll).toHaveBeenCalledTimes(1);
+      expect(miio.device.state).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(29999);
+      expect(miio.device.poll).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(1);
+      expect(miio.device.poll).toHaveBeenCalledTimes(2);
+      expect(miio.device.state).toHaveBeenCalledTimes(2);
+    });
+
+    test("does not start another refresh while one is still running", async () => {
+      let completePoll: (() => void) | undefined;
+      miio.device.poll.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            completePoll = resolve;
+          })
+      );
+      await createConnectedDeviceManager();
+
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(miio.device.poll).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(90000);
+      await Promise.resolve();
+      expect(miio.device.poll).toHaveBeenCalledTimes(1);
+
+      completePoll?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(30000);
+      expect(miio.device.poll).toHaveBeenCalledTimes(2);
+    });
+
+    test("replaces the polling timer when the device reconnects", async () => {
+      const deviceManager = await createConnectedDeviceManager();
+      await jest.advanceTimersByTimeAsync(0);
+
+      await (
+        deviceManager as unknown as { initializeDevice: () => Promise<void> }
+      ).initializeDevice();
+      await jest.advanceTimersByTimeAsync(0);
+      expect(miio.device.poll).toHaveBeenCalledTimes(2);
+
+      await jest.advanceTimersByTimeAsync(30000);
+      expect(miio.device.poll).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/src/services/device_manager.ts
+++ b/src/services/device_manager.ts
@@ -4,6 +4,7 @@ import {
   distinct,
   exhaustMap,
   filter,
+  Subscription,
   Subject,
   timer,
 } from "rxjs";
@@ -44,6 +45,7 @@ export class DeviceManager {
   public readonly deviceConnected$ = this.internalDevice$.pipe(filter(Boolean));
 
   private connectingPromise: Promise<void> | null = null;
+  private statePollingSubscription: Subscription | null = null;
   private connectRetry = setTimeout(() => void 0, 100); // Noop timeout only to initialise the property
   constructor(
     private readonly hap: HAP,
@@ -173,7 +175,10 @@ export class DeviceManager {
       );
 
       // Refresh the state every 30s so miio maintains a fresh connection (or recovers connection if lost until we fix https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/issues/81)
-      timer(0, GET_STATE_INTERVAL_MS).pipe(exhaustMap(() => this.getState()));
+      this.statePollingSubscription?.unsubscribe();
+      this.statePollingSubscription = timer(0, GET_STATE_INTERVAL_MS)
+        .pipe(exhaustMap(() => this.getState()))
+        .subscribe();
     } else {
       const model = (device || {}).miioModel;
       this.log.error(


### PR DESCRIPTION
## Summary

- subscribe to the existing 30-second RxJS state polling pipeline
- replace the active polling subscription after reconnecting to prevent duplicate requests
- add regression coverage for polling cadence, overlapping refresh suppression, and reconnection
- document the fix in the changelog

## Why

`DeviceManager` constructed the state polling observable but never subscribed to it. Because RxJS observables are lazy, the intended periodic refresh never ran, which also disabled the polling-based connection recovery path.

## Impact

Vacuum state is refreshed every 30 seconds as intended. Slow refreshes remain non-overlapping, and reconnections leave only one polling timer active.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --runInBand`

All 18 test suites, 116 tests, and 24 snapshots pass.
