### PR TITLE
Fix incompatibility with Homebridge 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - [Bug] Restore periodic vacuum state polling and connection recovery.
+- [Bug] Fix incompatibility issue with Homebridge v2.3.0 ([#1217](https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/issues/1217))
 
 ## 0.35.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/node": "24.13.3",
         "@types/semver": "7.7.1",
         "babel-jest": "30.4.1",
-        "homebridge": "^2.0.0-beta.23",
+        "homebridge": "2.4.0",
         "jest": "30.4.2",
         "prettier": "3.6.2",
         "rimraf": "6.1.3",
@@ -1835,12 +1835,13 @@
       }
     },
     "node_modules/@homebridge/ciao": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.4.tgz",
-      "integrity": "sha512-qK6ZgGx0wwOubq/MY6eTbhApQHBUQCvCOsTYpQE01uLvfA2/Prm6egySHlZouKaina1RPuDwfLhCmsRCxwHj3Q==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.12.tgz",
+      "integrity": "sha512-84/0u0kqKy4qcKupIDaTtbkmk+3qFDuMzxTC0NPfVlHcUT+jHGdP+QCqwEw94/GJxRezDeBLwxaclkBZgCdeUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.1",
+        "debug": "^4.4.3",
         "fast-deep-equal": "^3.1.3",
         "source-map-support": "^0.5.21",
         "tslib": "^2.8.1"
@@ -1854,26 +1855,81 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
     },
     "node_modules/@homebridge/dbus-native": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.1.tgz",
-      "integrity": "sha512-ZywUbf0vy+DSN4gCCMERRpSh/nywPjRk/fMq5GGM58Cqm8/dg6/C5aFJPmgVLNUD4Etcamq2d0Jb9qiDSZktcA==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.9.tgz",
+      "integrity": "sha512-PFOeWyXfH2eoM4o6Zmj9PzCUDlrrbtrbAJVzHYXpXK5rh/dz84Ygu79WHKK3DWW2/oXieYPV6up+i1izSPbc3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "event-stream": "^4.0.1",
-        "hexy": "^0.3.5",
+        "hexy": "^0.4.0",
         "long": "^5.3.2",
         "minimist": "^1.2.8",
-        "safe-buffer": "^5.1.2",
+        "safe-buffer": "^5.2.1",
         "xml2js": "^0.6.2"
       },
       "bin": {
         "dbus2js": "bin/dbus2js.js"
+      }
+    },
+    "node_modules/@homebridge/dbus-native/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@homebridge/hap-nodejs": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.2.2.tgz",
+      "integrity": "sha512-drTJSn63wGn5R6sDLmgjJdIW7G1awn1CxEEW1Jn+t3oCTMGSlk7lBZjGYbOpeL6acjiBqXNdo79NWcXn7s4CnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@homebridge/ciao": "1.3.12",
+        "@homebridge/dbus-native": "0.7.9",
+        "bonjour-hap": "3.10.5",
+        "debug": "^4.4.3",
+        "fast-srp-hap": "^2.0.4",
+        "futoin-hkdf": "^1.5.3",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": "^22 || ^24 || ^26"
+      }
+    },
+    "node_modules/@homebridge/hap-nodejs/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2451,7 +2507,98 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@matter/general": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.9.tgz",
+      "integrity": "sha512-NMAhD/EKpfTb1e0UllUJLdWgViw+Jp41PoY6s4yVGAiuo0sot6CYSdQauXelQPldhonrn2bLSKAa2mQUKWdhLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^2.2.0"
+      }
+    },
+    "node_modules/@matter/main": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.9.tgz",
+      "integrity": "sha512-YFBpU1AquN6sLC466xcOslAaERtlBnofHfuvDyY9B8UHZZJwFUfsDT7gMWVYkU5J/S9vc7lslL9TMvvns8Biaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9",
+        "@matter/node": "0.17.9",
+        "@matter/protocol": "0.17.9",
+        "@matter/types": "0.17.9"
+      },
+      "optionalDependencies": {
+        "@matter/nodejs": "0.17.9"
+      }
+    },
+    "node_modules/@matter/model": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.9.tgz",
+      "integrity": "sha512-NICGlK8ubD2an1eKIhEX2osZRl5JjnZE3Z8CJGnWItyVU5MbX1ta/EdCx/eBGy8WQPTxpYu93keW3L6qTUMOlg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.9"
+      }
+    },
+    "node_modules/@matter/node": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.9.tgz",
+      "integrity": "sha512-5AT6NYfIlLaILHAgVQoNZkuobff+CR7Ewkdj14YkENx77rRlujgDlDpXRiJkAHc+EUvRkwr5zA9ZL70XkwHkEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9",
+        "@matter/protocol": "0.17.9",
+        "@matter/types": "0.17.9"
+      }
+    },
+    "node_modules/@matter/nodejs": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.9.tgz",
+      "integrity": "sha512-2C3J89qeLyknLtbe/ls46dmjs/eN8LmMSKpGl90mC2ut8471z4rkpFYNE+MTJLFg8yzC+R86yi35Y3lBzioEwA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@matter/general": "0.17.9",
+        "@matter/node": "0.17.9",
+        "@matter/protocol": "0.17.9",
+        "@matter/types": "0.17.9"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+      }
+    },
+    "node_modules/@matter/protocol": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.9.tgz",
+      "integrity": "sha512-BZg1BWwm3rHsFxyQm17VjpTNO3kwd+AIjI9dtfnPFkH5CeS7r6Ebd/9j8L0zxeVPotciMcSW8H5W+3kCcuB2HQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9",
+        "@matter/types": "0.17.9"
+      }
+    },
+    "node_modules/@matter/types": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.9.tgz",
+      "integrity": "sha512-Tdb08WzfM2Ma962NTtNrHTA3S26eBGCj5/kpnpl9LS5Twpw78Rgk/jogOIM/HDVCbu/M/ZSQPmdBN/q3vWEXAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -2463,6 +2610,35 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.4.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3063,12 +3239,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
-      "dev": true
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -3235,13 +3405,13 @@
       }
     },
     "node_modules/bonjour-hap": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.9.0.tgz",
-      "integrity": "sha512-g/25iC9U3vYCwR8NvspPJhsl8kNgVSsXPbgAFO/+Gm0x6kn33XCL6CMvg79ZViAAo0NZRHqa5VR52eUw1zE2IA==",
+      "version": "3.10.5",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.5.tgz",
+      "integrity": "sha512-8E81oIQF0pjlDNVAKcAGwPYYG9BKD42Q8Fi7eJ/vYxEwyL/M8YpjM4gnFC1QTmagWI3jzbw7jPI0q2C1qWfQLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-flatten": "^3.0.0",
-        "deep-equal": "^2.2.3",
+        "fast-deep-equal": "^3.1.3",
         "multicast-dns": "^7.2.5",
         "multicast-dns-service-types": "^1.1.0"
       }
@@ -3453,12 +3623,13 @@
       "integrity": "sha1-bDKtndnA/gfM8thoBzR4FxIzK0A="
     },
     "node_modules/commander": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/concat-map": {
@@ -3630,6 +3801,7 @@
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
       "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
       },
@@ -3641,7 +3813,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dwaal": {
       "version": "0.1.4",
@@ -3811,6 +3984,7 @@
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
       "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "duplexer": "^0.1.1",
         "from": "^0.1.7",
@@ -3879,7 +4053,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3892,6 +4067,7 @@
       "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.4.tgz",
       "integrity": "sha512-lHRYYaaIbMrhZtsdGTwPN82UbqD9Bv8QfOlKs+Dz6YRnByZifOh93EYmf2iEWFtkOEIqR2IK8cFD0UN5wLIWBQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.17.0"
       }
@@ -3962,13 +4138,15 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -4030,6 +4208,7 @@
       "resolved": "https://registry.npmjs.org/futoin-hkdf/-/futoin-hkdf-1.5.3.tgz",
       "integrity": "sha512-SewY5KdMpaoCeh7jachEWFsh1nNlaDjNHZXWqL5IGwtpEYHTgkr2+AMCgNwKWkcc0wpSYrZfR7he4WdmHFtDxQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -4122,37 +4301,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
-    "node_modules/hap-nodejs": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-2.0.0-beta.2.tgz",
-      "integrity": "sha512-uclnhQm9oH3StxeuRLMTgPNR46c4g3Fo4dUUmoZsRS3sXFsilrMjF94lBGbd7baRikV9KqPrCPgGJZwop/jkeA==",
-      "dev": true,
-      "dependencies": {
-        "@homebridge/ciao": "^1.3.3",
-        "@homebridge/dbus-native": "^0.7.1",
-        "bonjour-hap": "^3.9.0",
-        "debug": "^4.4.1",
-        "fast-srp-hap": "^2.0.4",
-        "futoin-hkdf": "^1.5.3",
-        "node-persist": "^0.0.12",
-        "source-map-support": "^0.5.21",
-        "tslib": "^2.8.1",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": "^20 || ^22 || ^24"
-      }
-    },
-    "node_modules/hap-nodejs/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4231,55 +4379,60 @@
       }
     },
     "node_modules/hexy": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz",
-      "integrity": "sha512-UCP7TIZPXz5kxYJnNOym+9xaenxCLor/JyhKieo8y8/bJWunGh9xbhy3YrgYJUQ87WwfXGm05X330DszOfINZw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+      "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "hexy": "bin/hexy_cmd.js"
       },
       "engines": {
-        "node": ">=10.4"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/homebridge": {
-      "version": "2.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.0-beta.30.tgz",
-      "integrity": "sha512-8267HNuOYcxod1cShpUI1iyNKvnnsyWZudVKYqxvXmlSrTXPL68J/aHIUNh7PtZhCHJTGofLiQfWl4DFMvw1cA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.4.0.tgz",
+      "integrity": "sha512-yAc/jGC04h6LqcZTiO6aubzKmCulWGIdYUx3lj8r/aJQbAL5EZta9aX71LWnko3bChhTaD7sS7LLJ5Hqu4DbVA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "5.6.0",
-        "commander": "14.0.0",
-        "fs-extra": "11.3.1",
-        "hap-nodejs": "2.0.0-beta.2",
+        "@homebridge/hap-nodejs": "2.2.2",
+        "@matter/main": "0.17.9",
+        "chalk": "6.0.0",
+        "commander": "15.0.0",
+        "fs-extra": "11.4.0",
         "qrcode-terminal": "0.12.0",
-        "semver": "7.7.2",
+        "semver": "7.8.5",
         "source-map-support": "0.5.21"
       },
       "bin": {
         "homebridge": "bin/homebridge.js"
       },
       "engines": {
-        "node": "^20.7.0 || ^22 || ^24"
+        "node": "^22 || ^24 || ^26"
       }
     },
     "node_modules/homebridge/node_modules/chalk": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/homebridge/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5607,10 +5760,11 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -5654,7 +5808,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "11.0.0",
@@ -5693,7 +5848,8 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
       "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5782,6 +5938,7 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
       "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
@@ -5794,7 +5951,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -5822,16 +5980,6 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
-    },
-    "node_modules/node-persist": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
-      "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
-      "dev": true,
-      "dependencies": {
-        "mkdirp": "~0.5.1",
-        "q": "~1.1.1"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -6041,6 +6189,10 @@
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
       "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
       "dependencies": {
         "through": "~2.3"
       }
@@ -6151,17 +6303,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
-    },
-    "node_modules/q": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-      "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
     },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
@@ -6412,10 +6553,14 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "dev": true
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.1",
@@ -6541,6 +6686,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "through": "2"
       },
@@ -6582,6 +6728,7 @@
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "duplexer": "~0.1.1",
         "through": "~2.3.4"
@@ -6746,13 +6893,15 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinkerhub-discovery": {
       "version": "0.3.1",
@@ -6790,7 +6939,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -6877,6 +7027,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7115,6 +7266,7 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
       "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -7128,6 +7280,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -8424,12 +8577,12 @@
       }
     },
     "@homebridge/ciao": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.4.tgz",
-      "integrity": "sha512-qK6ZgGx0wwOubq/MY6eTbhApQHBUQCvCOsTYpQE01uLvfA2/Prm6egySHlZouKaina1RPuDwfLhCmsRCxwHj3Q==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.12.tgz",
+      "integrity": "sha512-84/0u0kqKy4qcKupIDaTtbkmk+3qFDuMzxTC0NPfVlHcUT+jHGdP+QCqwEw94/GJxRezDeBLwxaclkBZgCdeUg==",
       "dev": true,
       "requires": {
-        "debug": "^4.4.1",
+        "debug": "^4.4.3",
         "fast-deep-equal": "^3.1.3",
         "source-map-support": "^0.5.21",
         "tslib": "^2.8.1"
@@ -8448,17 +8601,54 @@
       }
     },
     "@homebridge/dbus-native": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.1.tgz",
-      "integrity": "sha512-ZywUbf0vy+DSN4gCCMERRpSh/nywPjRk/fMq5GGM58Cqm8/dg6/C5aFJPmgVLNUD4Etcamq2d0Jb9qiDSZktcA==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.9.tgz",
+      "integrity": "sha512-PFOeWyXfH2eoM4o6Zmj9PzCUDlrrbtrbAJVzHYXpXK5rh/dz84Ygu79WHKK3DWW2/oXieYPV6up+i1izSPbc3g==",
       "dev": true,
       "requires": {
         "event-stream": "^4.0.1",
-        "hexy": "^0.3.5",
+        "hexy": "^0.4.0",
         "long": "^5.3.2",
         "minimist": "^1.2.8",
-        "safe-buffer": "^5.1.2",
+        "safe-buffer": "^5.2.1",
         "xml2js": "^0.6.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
+    "@homebridge/hap-nodejs": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.2.2.tgz",
+      "integrity": "sha512-drTJSn63wGn5R6sDLmgjJdIW7G1awn1CxEEW1Jn+t3oCTMGSlk7lBZjGYbOpeL6acjiBqXNdo79NWcXn7s4CnQ==",
+      "dev": true,
+      "requires": {
+        "@homebridge/ciao": "1.3.12",
+        "@homebridge/dbus-native": "0.7.9",
+        "bonjour-hap": "3.10.5",
+        "debug": "^4.4.3",
+        "fast-srp-hap": "^2.0.4",
+        "futoin-hkdf": "^1.5.3",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "tweetnacl": "^1.0.3"
+      },
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
       }
     },
     "@isaacs/cliui": {
@@ -8908,6 +9098,84 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true
     },
+    "@matter/general": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.9.tgz",
+      "integrity": "sha512-NMAhD/EKpfTb1e0UllUJLdWgViw+Jp41PoY6s4yVGAiuo0sot6CYSdQauXelQPldhonrn2bLSKAa2mQUKWdhLQ==",
+      "dev": true,
+      "requires": {
+        "@noble/curves": "^2.2.0"
+      }
+    },
+    "@matter/main": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.9.tgz",
+      "integrity": "sha512-YFBpU1AquN6sLC466xcOslAaERtlBnofHfuvDyY9B8UHZZJwFUfsDT7gMWVYkU5J/S9vc7lslL9TMvvns8Biaw==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9",
+        "@matter/node": "0.17.9",
+        "@matter/nodejs": "0.17.9",
+        "@matter/protocol": "0.17.9",
+        "@matter/types": "0.17.9"
+      }
+    },
+    "@matter/model": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.9.tgz",
+      "integrity": "sha512-NICGlK8ubD2an1eKIhEX2osZRl5JjnZE3Z8CJGnWItyVU5MbX1ta/EdCx/eBGy8WQPTxpYu93keW3L6qTUMOlg==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.17.9"
+      }
+    },
+    "@matter/node": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.9.tgz",
+      "integrity": "sha512-5AT6NYfIlLaILHAgVQoNZkuobff+CR7Ewkdj14YkENx77rRlujgDlDpXRiJkAHc+EUvRkwr5zA9ZL70XkwHkEw==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9",
+        "@matter/protocol": "0.17.9",
+        "@matter/types": "0.17.9"
+      }
+    },
+    "@matter/nodejs": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.9.tgz",
+      "integrity": "sha512-2C3J89qeLyknLtbe/ls46dmjs/eN8LmMSKpGl90mC2ut8471z4rkpFYNE+MTJLFg8yzC+R86yi35Y3lBzioEwA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@matter/general": "0.17.9",
+        "@matter/node": "0.17.9",
+        "@matter/protocol": "0.17.9",
+        "@matter/types": "0.17.9"
+      }
+    },
+    "@matter/protocol": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.9.tgz",
+      "integrity": "sha512-BZg1BWwm3rHsFxyQm17VjpTNO3kwd+AIjI9dtfnPFkH5CeS7r6Ebd/9j8L0zxeVPotciMcSW8H5W+3kCcuB2HQ==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9",
+        "@matter/types": "0.17.9"
+      }
+    },
+    "@matter/types": {
+      "version": "0.17.9",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.9.tgz",
+      "integrity": "sha512-Tdb08WzfM2Ma962NTtNrHTA3S26eBGCj5/kpnpl9LS5Twpw78Rgk/jogOIM/HDVCbu/M/ZSQPmdBN/q3vWEXAw==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.17.9",
+        "@matter/model": "0.17.9"
+      }
+    },
     "@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -8919,6 +9187,21 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "@noble/curves": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
+      "dev": true,
+      "requires": {
+        "@noble/hashes": "2.4.0"
+      }
+    },
+    "@noble/hashes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
+      "dev": true
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -9360,12 +9643,6 @@
         "is-array-buffer": "^3.0.1"
       }
     },
-    "array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
-      "dev": true
-    },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -9492,13 +9769,12 @@
       "dev": true
     },
     "bonjour-hap": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.9.0.tgz",
-      "integrity": "sha512-g/25iC9U3vYCwR8NvspPJhsl8kNgVSsXPbgAFO/+Gm0x6kn33XCL6CMvg79ZViAAo0NZRHqa5VR52eUw1zE2IA==",
+      "version": "3.10.5",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.5.tgz",
+      "integrity": "sha512-8E81oIQF0pjlDNVAKcAGwPYYG9BKD42Q8Fi7eJ/vYxEwyL/M8YpjM4gnFC1QTmagWI3jzbw7jPI0q2C1qWfQLQ==",
       "dev": true,
       "requires": {
-        "array-flatten": "^3.0.0",
-        "deep-equal": "^2.2.3",
+        "fast-deep-equal": "^3.1.3",
         "multicast-dns": "^7.2.5",
         "multicast-dns-service-types": "^1.1.0"
       }
@@ -9645,9 +9921,9 @@
       "integrity": "sha1-bDKtndnA/gfM8thoBzR4FxIzK0A="
     },
     "commander": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true
     },
     "concat-map": {
@@ -10053,9 +10329,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
@@ -10164,36 +10440,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
-    "hap-nodejs": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-2.0.0-beta.2.tgz",
-      "integrity": "sha512-uclnhQm9oH3StxeuRLMTgPNR46c4g3Fo4dUUmoZsRS3sXFsilrMjF94lBGbd7baRikV9KqPrCPgGJZwop/jkeA==",
-      "dev": true,
-      "requires": {
-        "@homebridge/ciao": "^1.3.3",
-        "@homebridge/dbus-native": "^0.7.1",
-        "bonjour-hap": "^3.9.0",
-        "debug": "^4.4.1",
-        "fast-srp-hap": "^2.0.4",
-        "futoin-hkdf": "^1.5.3",
-        "node-persist": "^0.0.12",
-        "source-map-support": "^0.5.21",
-        "tslib": "^2.8.1",
-        "tweetnacl": "^1.0.3"
-      },
-      "dependencies": {
-        "source-map-support": {
-          "version": "0.5.21",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        }
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -10242,36 +10488,37 @@
       }
     },
     "hexy": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz",
-      "integrity": "sha512-UCP7TIZPXz5kxYJnNOym+9xaenxCLor/JyhKieo8y8/bJWunGh9xbhy3YrgYJUQ87WwfXGm05X330DszOfINZw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+      "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
       "dev": true
     },
     "homebridge": {
-      "version": "2.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.0-beta.30.tgz",
-      "integrity": "sha512-8267HNuOYcxod1cShpUI1iyNKvnnsyWZudVKYqxvXmlSrTXPL68J/aHIUNh7PtZhCHJTGofLiQfWl4DFMvw1cA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.4.0.tgz",
+      "integrity": "sha512-yAc/jGC04h6LqcZTiO6aubzKmCulWGIdYUx3lj8r/aJQbAL5EZta9aX71LWnko3bChhTaD7sS7LLJ5Hqu4DbVA==",
       "dev": true,
       "requires": {
-        "chalk": "5.6.0",
-        "commander": "14.0.0",
-        "fs-extra": "11.3.1",
-        "hap-nodejs": "2.0.0-beta.2",
+        "@homebridge/hap-nodejs": "2.2.2",
+        "@matter/main": "0.17.9",
+        "chalk": "6.0.0",
+        "commander": "15.0.0",
+        "fs-extra": "11.4.0",
         "qrcode-terminal": "0.12.0",
-        "semver": "7.7.2",
+        "semver": "7.8.5",
         "source-map-support": "0.5.21"
       },
       "dependencies": {
         "chalk": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-          "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+          "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
           "dev": true
         },
         "semver": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-          "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+          "version": "7.8.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
           "dev": true
         },
         "source-map-support": {
@@ -11246,9 +11493,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
@@ -11414,16 +11661,6 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
-    },
-    "node-persist": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
-      "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "~0.5.1",
-        "q": "~1.1.1"
-      }
     },
     "node-releases": {
       "version": "2.0.27",
@@ -11643,12 +11880,6 @@
       "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
       "dev": true
     },
-    "q": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-      "integrity": "sha512-ROtylwux7Vkc4C07oKE/ReigUmb33kVoLtcR4SJ1QVqwaZkBEDL3vX4/kwFzIERQ5PfCl0XafbU8u2YUhyGgVA==",
-      "dev": true
-    },
     "qrcode-terminal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
@@ -11835,9 +12066,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "dev": true
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "homebridge": "^1.6.0 || ^2.0.0-beta.0",
-    "node": "^18.20.4 || ^20.15.1 || ^22.0.0 || ^24.0.0"
+    "homebridge": "^2.3.0",
+    "node": "^22 || ^24 || ^26"
   },
   "scripts": {
     "clean": "rimraf ./dist",
@@ -70,7 +70,7 @@
     "@types/node": "24.13.3",
     "@types/semver": "7.7.1",
     "babel-jest": "30.4.1",
-    "homebridge": "^2.0.0-beta.23",
+    "homebridge": "2.4.0",
     "jest": "30.4.2",
     "prettier": "3.6.2",
     "rimraf": "6.1.3",

--- a/src/services/battery_info.test.ts
+++ b/src/services/battery_info.test.ts
@@ -1,5 +1,5 @@
 import { HAP } from "homebridge";
-import * as HapJs from "hap-nodejs";
+import * as HapJs from "@homebridge/hap-nodejs";
 import { Subject } from "rxjs";
 import { BatteryInfo } from "./battery_info";
 import {

--- a/src/services/care_service.test.ts
+++ b/src/services/care_service.test.ts
@@ -1,5 +1,5 @@
 import { HAP } from "homebridge";
-import * as HapJs from "hap-nodejs";
+import * as HapJs from "@homebridge/hap-nodejs";
 import { CareService } from "./care_service";
 import { createHomebridgeMock } from "../test.mocks";
 import { getLoggerMock } from "../utils/logger.mock";

--- a/src/services/dock_service.test.ts
+++ b/src/services/dock_service.test.ts
@@ -1,5 +1,5 @@
 import { HAP } from "homebridge";
-import * as HapJs from "hap-nodejs";
+import * as HapJs from "@homebridge/hap-nodejs";
 import { Subject } from "rxjs";
 import { DockService } from "./dock_service";
 import {

--- a/src/services/dust_bin_service.ts
+++ b/src/services/dust_bin_service.ts
@@ -1,8 +1,7 @@
-import { Service } from "homebridge";
+import { Service, CharacteristicValue } from "homebridge";
 import { BehaviorSubject, distinct, filter } from "rxjs";
 import { CoreContext } from "./types";
 import { PluginServiceClass } from "./plugin_service_class";
-import { CharacteristicValue } from "hap-nodejs/dist/types";
 
 export interface DustBinConfig {
   dustBin: boolean;

--- a/src/services/find_me_service.test.ts
+++ b/src/services/find_me_service.test.ts
@@ -1,5 +1,5 @@
 import { HAP } from "homebridge";
-import * as HapJs from "hap-nodejs";
+import * as HapJs from "@homebridge/hap-nodejs";
 import { Subject } from "rxjs";
 import { FindMeService } from "./find_me_service";
 import {

--- a/src/services/find_me_service.ts
+++ b/src/services/find_me_service.ts
@@ -1,5 +1,4 @@
-import { Service } from "homebridge";
-import { CharacteristicValue } from "hap-nodejs/dist/types";
+import { Service, CharacteristicValue } from "homebridge";
 import { CoreContext } from "./types";
 import { PluginServiceClass } from "./plugin_service_class";
 import { ensureName } from "../utils/ensure_name";

--- a/src/services/product_info.test.ts
+++ b/src/services/product_info.test.ts
@@ -1,5 +1,5 @@
 import { HAP } from "homebridge";
-import * as HapJs from "hap-nodejs";
+import * as HapJs from "@homebridge/hap-nodejs";
 import { Subject } from "rxjs";
 import { ProductInfo } from "./product_info";
 import {

--- a/src/services/rooms_service.test.ts
+++ b/src/services/rooms_service.test.ts
@@ -1,5 +1,5 @@
 import { HAP } from "homebridge";
-import * as HapJs from "hap-nodejs";
+import * as HapJs from "@homebridge/hap-nodejs";
 import { Subject } from "rxjs";
 import { RoomsService } from "./rooms_service";
 import {

--- a/src/services/water_box_service.test.ts
+++ b/src/services/water_box_service.test.ts
@@ -1,5 +1,5 @@
 import { HAP } from "homebridge";
-import * as HapJs from "hap-nodejs";
+import * as HapJs from "@homebridge/hap-nodejs";
 import { findSpeedModesMock } from "./water_box_service.test.mock";
 import { WaterBoxService } from "./water_box_service";
 import { getLoggerMock, LoggerMock } from "../utils/logger.mock";

--- a/src/test.mocks.ts
+++ b/src/test.mocks.ts
@@ -1,7 +1,7 @@
 // ============= MIIO MOCKS ================
 
 import { API } from "homebridge";
-import { Characteristic, HAPStorage } from "hap-nodejs";
+import { Characteristic, HAPStorage } from "@homebridge/hap-nodejs";
 import { Socket } from "net";
 import { MiioDevice } from "./utils/miio_types";
 

--- a/src/utils/ensure_name.test.ts
+++ b/src/utils/ensure_name.test.ts
@@ -1,8 +1,8 @@
-import * as hap from "hap-nodejs";
+import * as hap from "@homebridge/hap-nodejs";
 import { ensureName } from "./ensure_name";
 
 describe("ensureName", () => {
-  const getItemSpy = jest.spyOn(hap.HAPStorage.storage(), "getItemSync");
+  const getItemSpy = jest.spyOn(hap.HAPStorage.storage(), "getItem");
   const setItemSpy = jest.spyOn(hap.HAPStorage.storage(), "setItemSync");
 
   const service = new hap.Service.Switch("test", "test");

--- a/src/utils/ensure_name.ts
+++ b/src/utils/ensure_name.ts
@@ -7,7 +7,7 @@ export function ensureName(hap: HAP, service: Service, name: string) {
     name.replaceAll(" ", "_"),
   ].join("-");
   service.addOptionalCharacteristic(hap.Characteristic.ConfiguredName);
-  if (!hap.HAPStorage.storage().getItemSync(key)) {
+  if (!hap.HAPStorage.storage().getItem(key)) {
     service.setCharacteristic(hap.Characteristic.ConfiguredName, name);
   }
   service

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "allowJs": true,
     "checkJs": false,
     "noImplicitAny": false,
+    "skipLibCheck": true,
 
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Resolves https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/issues/1217

* Updates dev dependency `homebridge` to the latest.
* Fixes broken imports after the library upgrade
* Addresses a breaking change in `HAPStorage`